### PR TITLE
Cleanup swagger client

### DIFF
--- a/swaggerpy/async_http_client.py
+++ b/swaggerpy/async_http_client.py
@@ -9,7 +9,7 @@
 """
 
 from cStringIO import StringIO
-import json
+from swaggerpy.compat import json
 import logging
 
 import crochet

--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -243,6 +243,7 @@ class Resource(object):
     def from_api_doc(cls, api_doc, http_client, base_path, url_base=None):
         """
         :param api_doc: api doc which defines this resource
+        :type  api_doc: :class:`dict`
         :param http_client: a :class:`swaggerpy.http_client.HttpClient`
         :param base_path: base url to perform api requests. Used to override
                 the path provided in the api spec

--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -6,7 +6,7 @@
 """Swagger client library.
 """
 
-import json
+from swaggerpy.compat import json
 import logging
 import os.path
 import time

--- a/swaggerpy/compat.py
+++ b/swaggerpy/compat.py
@@ -1,0 +1,5 @@
+
+try:
+    import simplejson as json
+except ImportError:
+    import json

--- a/swaggerpy/compat.py
+++ b/swaggerpy/compat.py
@@ -2,4 +2,4 @@
 try:
     import simplejson as json
 except ImportError:
-    import json
+    import json  # noqa

--- a/swaggerpy/http_client.py
+++ b/swaggerpy/http_client.py
@@ -24,13 +24,6 @@ MULT_FORM = 'multipart/form-data'
 class HttpClient(object):
     """Interface for a minimal HTTP client.
     """
-
-    def close(self):
-        """Close this client resource.
-        """
-        raise NotImplementedError(
-            u"%s: Method not implemented", self.__class__.__name__)
-
     def request(self, method, url, params=None, data=None):
         """Issue an HTTP request.
 
@@ -181,9 +174,6 @@ class SynchronousHttpClient(HttpClient):
     def __init__(self):
         self.session = requests.Session()
         self.authenticator = None
-
-    def close(self):
-        self.session.close()
 
     def start_request(self, request_params):
         """

--- a/swaggerpy/response.py
+++ b/swaggerpy/response.py
@@ -7,8 +7,6 @@
 """Code for checking the response from API. If correct, it proceeds to convert
 it into Python class types
 """
-import sys
-
 import swagger_type
 from swagger_type import SwaggerTypeCheck
 from swaggerpy.exception import CancelledError
@@ -17,17 +15,15 @@ from swaggerpy.exception import CancelledError
 DEFAULT_TIMEOUT_S = 5.0
 
 
-def handle_response_errors(e, CustomError):
+# TODO: why is this messing with exceptions? It's not going to work with all
+# http clients
+def handle_response_errors(e):
     if hasattr(e, 'response') and hasattr(e.response, 'text'):
         # e.args is a tuple, change to list for modifications
         args = list(e.args)
         args[0] += (' : ' + e.response.text)
         e.args = tuple(args)
-    if CustomError:
-        error_msg = type(e).__name__ + " : " + str(e)
-        raise CustomError(error_msg), None, sys.exc_info()[2]
-    else:
-        raise e
+    raise e
 
 
 class HTTPFuture(object):
@@ -79,7 +75,7 @@ class HTTPFuture(object):
         try:
             response.raise_for_status()
         except Exception as e:
-            handle_response_errors(e, self._http_client.raise_with)
+            handle_response_errors(e)
 
         return self._postHTTP_callback(response, **kwargs)
 

--- a/swaggerpy/response.py
+++ b/swaggerpy/response.py
@@ -179,7 +179,7 @@ class SwaggerResponseConstruct(object):
         """Creates empty instance of complex object and then fills it with attrs
         Assume the response is validated and correct
         """
-        klass = getattr(self._models, self._type)
+        klass = self._models[self._type]
         instance = klass()
         setattr(instance, '_raw', self._response)
         for key in self._response.keys():

--- a/swaggerpy/response.py
+++ b/swaggerpy/response.py
@@ -29,16 +29,16 @@ def handle_response_errors(e):
 class HTTPFuture(object):
 
     """A future which inputs HTTP params"""
-    def __init__(self, http_client, request_params, postHTTP_callback):
+    def __init__(self, http_client, request_params, post_receive):
         """Kicks API call for Asynchronous client
 
         :param http_client: instance with public methods:
             start_request(), wait(), cancel()
         :param request_params: dict containing API request parameters
-        :param postHTTP_callback: function to callback on finish
+        :param post_receive: function to callback on finish
         """
         self._http_client = http_client
-        self._postHTTP_callback = postHTTP_callback
+        self._post_receive = post_receive
         # A request is an EventualResult in the async client
         self._request = self._http_client.start_request(request_params)
         self._cancelled = False
@@ -77,7 +77,7 @@ class HTTPFuture(object):
         except Exception as e:
             handle_response_errors(e)
 
-        return self._postHTTP_callback(response, **kwargs)
+        return self._post_receive(response, **kwargs)
 
 
 def post_receive(response, type_, models, **kwargs):

--- a/swaggerpy/response.py
+++ b/swaggerpy/response.py
@@ -80,12 +80,13 @@ class HTTPFuture(object):
         return self._postHTTP_callback(response, **kwargs)
 
 
-class SwaggerResponse(object):
-    """Converts the API json response to Python class models
+def post_receive(response, type_, models, **kwargs):
+    """Convert the response body to swagger models.
 
-    Example: ::
+    Example API Response
 
-        API Response
+    .. code-block:: python
+
             {
                 "id": 1,
                 "category": {
@@ -103,36 +104,33 @@ class SwaggerResponse(object):
                 "status": "available"
             }
 
-    SwaggerResponse: ::
+    SwaggerResponse:
+
+    ..code-block:: python
 
         Pet(category=Category(id=0L, name=u'chihuahua'),
             status=u'available', name=u'tommy',
             tags=[Tag(id=0L, name=u'cute')], photoUrls=[u''], id=1)
 
+    :param response: response body
+    :type response: dict
+    :param type_: expected swagger type
+    :type type_: str or unicode
+    :param models: namedtuple which maps complex type string to py type
+    :type models: namedtuple
     """
+    allow_null = kwargs.pop('allow_null', False)
 
-    def __init__(self, response, type_, models, **kwargs):
-        """Wrapper to check and construt swagger response instance from API response
+    if kwargs.pop('raw_response', False):
+        return response
 
-        :param response: JSON response
-        :type response: dict
-        :param type_: type against which the response is to be validated
-        :type type_: str or unicode
-        :param models: namedtuple which maps complex type string to py type
-        :type models: namedtuple
-        """
-        allow_null = kwargs.pop('allow_null', False)
-        raw_response = kwargs.pop('raw_response', False)
-
-        if raw_response:
-            self.swagger_object = response
-            return
-
-        response = SwaggerTypeCheck("Response", response, type_, models,
-                                    allow_null).value
-        self.swagger_object = SwaggerResponseConstruct(response,
-                                                       type_,
-                                                       models).create_object()
+    response = SwaggerTypeCheck(
+        "Response",
+        response,
+        type_,
+        models,
+        allow_null).value
+    return SwaggerResponseConstruct(response, type_, models).create_object()
 
 
 class SwaggerResponseConstruct(object):

--- a/swaggerpy/swagger_model.py
+++ b/swaggerpy/swagger_model.py
@@ -9,7 +9,7 @@
 """
 
 import logging
-import json
+from swaggerpy.compat import json
 import os
 import urllib
 import urlparse

--- a/swaggerpy/swagger_type.py
+++ b/swaggerpy/swagger_type.py
@@ -325,7 +325,7 @@ class SwaggerTypeCheck(object):
         """Checks all the fields in the complex type are of proper type
         All the required fields are present and no extra field is present
         """
-        klass = getattr(self.models, self._type)
+        klass = self.models[self._type]
         if isinstance(self.value, klass):
             self.value = self.value._flat_dict()
         # The only valid type from this point on is JSON dict

--- a/tests/async_http_client_test.py
+++ b/tests/async_http_client_test.py
@@ -11,7 +11,7 @@ Not Tested:
 2) Timeouts by crochet's wait()
 """
 
-import json
+from swaggerpy.compat import json
 import unittest
 from collections import namedtuple
 from mock import patch, Mock

--- a/tests/client_http_test.py
+++ b/tests/client_http_test.py
@@ -1,14 +1,8 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 #
 # Copyright (c) 2013, Digium, Inc.
 # Copyright (c) 2014, Yelp, Inc.
 #
-
-"""Swagger client tests.
-"""
-
 import unittest
 
 import httpretty
@@ -72,7 +66,7 @@ class ClientTest(unittest.TestCase):
             body=open('test-data/1.2/simple/simple1.json', 'r').read())
 
         # Default handlers for all swagger.py access
-        self.client = SwaggerClient(u'http://localhost/api-docs')
+        self.client = SwaggerClient.from_url(u'http://localhost/api-docs')
 
 
 if __name__ == '__main__':

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -52,16 +52,16 @@ class SwaggerClientFactoryTest(unittest.TestCase):
     def setUp(self):
         client.factory = None
 
-    def test_is_stale_returns_true_after_timeout(self):
+    def test_is_stale_returns_true_after_ttl(self):
         with patch('swaggerpy.client.SwaggerClient'):
             with patch('swaggerpy.client.time.time', side_effect=[1]):
-                client.get_client('test', timeout=10)
+                client.get_client('test', ttl=10)
                 self.assertTrue(client.factory.cache['test'].is_stale(12))
 
-    def test_is_stale_returns_false_before_timeout(self):
+    def test_is_stale_returns_false_before_ttl(self):
         with patch('swaggerpy.client.SwaggerClient'):
             with patch('swaggerpy.client.time.time', side_effect=[1]):
-                client.get_client('test', timeout=10)
+                client.get_client('test', ttl=10)
                 self.assertFalse(client.factory.cache['test'].is_stale(11))
 
     def test_build_cached_client_with_proper_values(self):
@@ -70,9 +70,9 @@ class SwaggerClientFactoryTest(unittest.TestCase):
             with patch('swaggerpy.client.time.time',
                        side_effect=[1, 1]):
                 client_object = SwaggerClientFactory().build_cached_client(
-                    'test', timeout=3)
+                    'test', ttl=3)
                 self.assertEqual('foo', client_object.swagger_client)
-                self.assertEqual(3, client_object.timeout)
+                self.assertEqual(3, client_object.ttl)
                 self.assertEqual(1, client_object.timestamp)
 
     def test_builds_client_if_not_present_in_cache(self):
@@ -84,14 +84,14 @@ class SwaggerClientFactoryTest(unittest.TestCase):
     def test_builds_client_if_present_in_cache_but_stale(self):
         with patch('swaggerpy.client.time.time', side_effect=[2, 3]):
             client.factory = client.SwaggerClientFactory()
-            client.factory.cache['foo'] = client.CachedClient('bar', 0, 1)
+            client.factory.cache['foo'] = client.CacheEntry('bar', 0, 1)
             with patch('swaggerpy.client.SwaggerClient.from_url') as mock:
                 client.get_client('foo')
                 mock.assert_called_once_with('foo')
 
     def test_uses_the_cache_if_present_and_fresh(self):
         client.factory = client.SwaggerClientFactory()
-        client.factory.cache['foo'] = client.CachedClient('bar', 2, 1)
+        client.factory.cache['foo'] = client.CacheEntry('bar', 2, 1)
         with patch('swaggerpy.client.SwaggerClient') as mock:
             with patch('swaggerpy.client.time.time', side_effect=[2]):
                 client.get_client('foo')

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -9,7 +9,7 @@
 """
 
 import datetime
-import json
+from swaggerpy.compat import json
 import unittest
 
 import httpretty

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -182,15 +182,6 @@ class ClientTest(unittest.TestCase):
         self.assertEqual('bike', httpretty.last_request().headers['sweet'])
 
     @httpretty.activate
-    def test_raise_with_wrapper(self):
-        class MyException(Exception):
-            pass
-        self.uut = SwaggerClient(self.resource_listing, raise_with=MyException)
-        httpretty.register_uri(
-            httpretty.GET, "http://swagger.py/swagger-test/pet", status=500)
-        self.assertRaises(MyException, self.uut.pet.listPets().result)
-
-    @httpretty.activate
     def test_get(self):
         httpretty.register_uri(
             httpretty.GET, "http://swagger.py/swagger-test/pet",

--- a/tests/resource_api_test.py
+++ b/tests/resource_api_test.py
@@ -24,7 +24,7 @@ A sample 'resource api' is listed in the "apis" list below.
 }
 """
 
-import json
+from swaggerpy.compat import json
 import unittest
 
 import httpretty

--- a/tests/resource_api_test.py
+++ b/tests/resource_api_test.py
@@ -74,7 +74,7 @@ class ResourceApiTest(unittest.TestCase):
         def iterate_test(field):
             self.response["apis"][0].pop(field)
             self.register_urls()
-            self.assertRaises(SwaggerError, SwaggerClient,
+            self.assertRaises(SwaggerError, SwaggerClient.from_url,
                               u'http://localhost/api-docs')
         [iterate_test(field) for field in ('path', 'operations')]
 

--- a/tests/resource_listing_test.py
+++ b/tests/resource_listing_test.py
@@ -25,7 +25,7 @@ Sample 'resource_listing' this test intends to check is like:
 }
 """
 
-import json
+from swaggerpy.compat import json
 import unittest
 
 import httpretty

--- a/tests/resource_listing_test.py
+++ b/tests/resource_listing_test.py
@@ -52,14 +52,14 @@ class ResourceListingTest(unittest.TestCase):
     def test_error_on_wrong_swagger_version(self):
         self.response["swaggerVersion"] = "XYZ"
         self.register_urls()
-        self.assertRaises(SwaggerError, SwaggerClient,
+        self.assertRaises(SwaggerError, SwaggerClient.from_url,
                           u'http://localhost/api-docs')
 
     @httpretty.activate
     def test_error_on_missing_path_in_apis(self):
         self.response['apis'] = [{}]
         self.register_urls()
-        self.assertRaises(SwaggerError, SwaggerClient,
+        self.assertRaises(SwaggerError, SwaggerClient.from_url,
                           u'http://localhost/api-docs')
 
     @httpretty.activate
@@ -67,7 +67,7 @@ class ResourceListingTest(unittest.TestCase):
         def iterate_test(field):
             self.response.pop(field)
             self.register_urls()
-            self.assertRaises(SwaggerError, SwaggerClient,
+            self.assertRaises(SwaggerError, SwaggerClient.from_url,
                               u'http://localhost/api-docs')
         [iterate_test(field) for field in ('swaggerVersion', 'apis')]
 
@@ -77,7 +77,7 @@ class ResourceListingTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/api-docs/api",
             body='{"swaggerVersion": "1.2", "basePath": "/", "apis":[]}')
-        self.client = SwaggerClient(u'http://localhost/api-docs')
+        self.client = SwaggerClient.from_url(u'http://localhost/api-docs')
         self.assertNotEqual(None, self.client)
 
 

--- a/tests/resource_model_test.py
+++ b/tests/resource_model_test.py
@@ -48,7 +48,7 @@ A sample 'model' is listed below in models list.
 }
 """
 
-import json
+from swaggerpy.compat import json
 import unittest
 
 import httpretty

--- a/tests/resource_model_test.py
+++ b/tests/resource_model_test.py
@@ -147,7 +147,7 @@ class ResourceTest(unittest.TestCase):
     @httpretty.activate
     def test_success_on_model_types_creation(self):
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         User = resource.models.User
         self.assertEqual({"schools": [], "id": 0L}, User().__dict__)
 
@@ -160,7 +160,7 @@ class ResourceTest(unittest.TestCase):
             'type': 'string',
             'format': 'date-time'}
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         User = resource.models.User
         self.assertEqual(
             {"schools": [], "id": 0L, "date": None, "datetime": None},
@@ -170,7 +170,7 @@ class ResourceTest(unittest.TestCase):
     @httpretty.activate
     def test_success_on_model_types_instantiation(self):
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         User = resource.models.User
         School = resource.models.School
         user = User(id=42, schools=[School(name="a"), School(name="b")])
@@ -184,13 +184,13 @@ class ResourceTest(unittest.TestCase):
         self.response["models"]["School"]["properties"]["name"][
             "type"] = "WRONG_TYPE"
         self.register_urls()
-        self.assertRaises(TypeError, SwaggerClient,
+        self.assertRaises(TypeError, SwaggerClient.from_url,
                           u'http://localhost/api-docs')
 
     @httpretty.activate
     def test_error_on_extra_attr_during_model_types_instantiation(self):
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         User = resource.models.User
         self.assertRaises(AttributeError, User, extra=42)
 
@@ -199,7 +199,7 @@ class ResourceTest(unittest.TestCase):
         def iterate_test(field):
             self.response["models"]["User"].pop(field)
             self.register_urls()
-            self.assertRaises(SwaggerError, SwaggerClient,
+            self.assertRaises(SwaggerError, SwaggerClient.from_url,
                               u'http://localhost/api-docs')
         [iterate_test(field) for field in ('id', 'properties')]
 
@@ -207,13 +207,13 @@ class ResourceTest(unittest.TestCase):
     def test_error_on_model_name_and_id_mismatch(self):
         self.response["models"]["User"]["id"] = "NotUser"
         self.register_urls()
-        self.assertRaises(SwaggerError, SwaggerClient,
+        self.assertRaises(SwaggerError, SwaggerClient.from_url,
                           u'http://localhost/api-docs')
 
     @httpretty.activate
     def test_setattrs_on_client_and_model(self):
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         models = resource.models
         self.assertTrue(isinstance(models, tuple))
         self.assertNotEqual(None, models.User)
@@ -229,7 +229,7 @@ class ResourceTest(unittest.TestCase):
     @httpretty.activate
     def test_types_of_model_attributes(self):
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         models = resource.models
         user = models.User()
         school = models.School()
@@ -248,7 +248,7 @@ class ResourceTest(unittest.TestCase):
         self.response["models"]["User"]["properties"]["school"] = {
             "$ref": "School"}
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         self.assertTrue('school' in resource.models.User().__dict__)
 
     @httpretty.activate
@@ -261,7 +261,7 @@ class ResourceTest(unittest.TestCase):
         # Empty dict assigned which means no ref or no type
         self.response["models"]["User"]["properties"]["school"] = {}
         self.register_urls()
-        self.assertRaises(TypeError, SwaggerClient,
+        self.assertRaises(TypeError, SwaggerClient.from_url,
                           u'http://localhost/api-docs')
 
     @httpretty.activate
@@ -269,7 +269,7 @@ class ResourceTest(unittest.TestCase):
         self.response["models"]["User"]["properties"]["school"] = {
             "$ref": "string"}
         self.register_urls()
-        self.assertRaises(TypeError, SwaggerClient,
+        self.assertRaises(TypeError, SwaggerClient.from_url,
                           u'http://localhost/api-docs')
 
     @httpretty.activate
@@ -277,7 +277,7 @@ class ResourceTest(unittest.TestCase):
         self.response["models"]["User"]["properties"]["school"] = {
             "type": "School"}
         self.register_urls()
-        self.assertRaises(TypeError, SwaggerClient,
+        self.assertRaises(TypeError, SwaggerClient.from_url,
                           u'http://localhost/api-docs')
 
     ###########################################################################
@@ -293,7 +293,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resp = resource.testHTTP().result()
         User = resource.models.User
         School = resource.models.School
@@ -309,7 +309,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        self.assertRaises(AssertionError, SwaggerClient(
+        self.assertRaises(AssertionError, SwaggerClient.from_url(
             u'http://localhost/api-docs').api_test.testHTTP().result)
 
     @httpretty.activate
@@ -319,7 +319,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        result = SwaggerClient(
+        result = SwaggerClient.from_url(
             u'http://localhost/api-docs').api_test.testHTTP().result()
         self.assertEqual(result._raw["extra"], 42)
 
@@ -329,7 +329,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body='"NOT_COMPLEX_TYPE"')
-        self.assertRaises(TypeError, SwaggerClient(
+        self.assertRaises(TypeError, SwaggerClient.from_url(
             u'http://localhost/api-docs').api_test.testHTTP().result)
 
     @httpretty.activate
@@ -339,7 +339,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        self.assertRaises(TypeError, SwaggerClient(
+        self.assertRaises(TypeError, SwaggerClient.from_url(
             u'http://localhost/api-docs').api_test.testHTTP().result)
 
     @httpretty.activate
@@ -349,7 +349,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        self.assertRaises(TypeError, SwaggerClient(
+        self.assertRaises(TypeError, SwaggerClient.from_url(
             u'http://localhost/api-docs').api_test.testHTTP().result)
 
     @httpretty.activate
@@ -359,7 +359,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        self.assertRaises(AssertionError, SwaggerClient(
+        self.assertRaises(AssertionError, SwaggerClient.from_url(
             u'http://localhost/api-docs').api_test.testHTTP().result)
 
     @httpretty.activate
@@ -374,7 +374,7 @@ class ResourceTest(unittest.TestCase):
         self.response["apis"][0]["operations"][0]["parameters"] = [
             query_parameter]
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         school = resource.models.School()
         self.assertRaises(TypeError, resource.testHTTP, test_param=school)
 
@@ -385,7 +385,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resp = resource.testHTTP().result(allow_null=True)
         self.assertTrue(isinstance(resp, resource.models.User))
 
@@ -395,7 +395,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(None))
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resource.testHTTP().result(allow_null=True)
 
     @httpretty.activate
@@ -405,7 +405,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         self.assertRaises(TypeError, resource.testHTTP().result)
 
     @httpretty.activate
@@ -414,7 +414,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(None))
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         self.assertRaises(TypeError, resource.testHTTP().result)
 
     @httpretty.activate
@@ -423,7 +423,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         School = resource.models.School
         User = resource.models.User
         user = User(schools=[School(name='a'), None])
@@ -444,7 +444,7 @@ class ResourceTest(unittest.TestCase):
         self.response["apis"][1]["operations"][0]["parameters"] = [
             query_parameter]
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
 
         School = resource.models.School
         # Also test all None items are removed from array list
@@ -467,7 +467,7 @@ class ResourceTest(unittest.TestCase):
         self.response["models"]["User"]["properties"]["school"] = {
             "$ref": "School"}
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         user = resource.models.User(id=42)
         future = resource.testHTTPPost(body=user)
         # Removed the 'school': None - key, value pair from dict
@@ -489,7 +489,7 @@ class ResourceTest(unittest.TestCase):
             "$ref": "School"}
         self.response["models"]["User"]["required"] = ["school"]
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         user = resource.models.User(id=42)
         self.assertRaises(AttributeError, resource.testHTTPPost, body=user)
 
@@ -512,7 +512,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(school))
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resource.testHTTPPost(body=school).result()
         self.assertEqual("application/json", httpretty.last_request().headers[
             'content-type'])
@@ -530,8 +530,8 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps({'id': 1}))
-        SwaggerClient(u'http://localhost/api-docs').api_test.testHTTPPost(
-            body=42).result()
+        client = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
+        client.testHTTPPost(body=42).result()
         self.assertFalse('content-type' in httpretty.last_request().headers)
 
 

--- a/tests/resource_operation_test.py
+++ b/tests/resource_operation_test.py
@@ -98,7 +98,7 @@ class ResourceOperationTest(unittest.TestCase):
         def iterate_test(field):
             self.response["apis"][0]["operations"][0].pop(field)
             self.register_urls()
-            self.assertRaises(SwaggerError, SwaggerClient,
+            self.assertRaises(SwaggerError, SwaggerClient.from_url,
                               u'http://localhost/api-docs')
         [iterate_test(field) for field in ('method', 'nickname', 'type',
                                            'parameters')]
@@ -114,7 +114,7 @@ class ResourceOperationTest(unittest.TestCase):
             self.response["apis"][0]["operations"][0]["parameters"][0].pop(
                 field)
             self.register_urls()
-            self.assertRaises(SwaggerError, SwaggerClient,
+            self.assertRaises(SwaggerError, SwaggerClient.from_url,
                               u'http://localhost/api-docs')
         [iterate_test(field) for field in ('type', 'paramType', 'name')]
 
@@ -122,7 +122,7 @@ class ResourceOperationTest(unittest.TestCase):
     def test_error_on_missing_items_param_in_array_parameter(self):
         self.response["apis"][0]["operations"][0]["type"] = "array"
         self.register_urls()
-        self.assertRaises(SwaggerError, SwaggerClient,
+        self.assertRaises(SwaggerError, SwaggerClient.from_url,
                           u'http://localhost/api-docs')
 
     @httpretty.activate
@@ -131,7 +131,7 @@ class ResourceOperationTest(unittest.TestCase):
         params.append({"paramType": "body", "type": "string", "name": "a"})
         params.append({"paramType": "form", "type": "string", "name": "b"})
         self.register_urls()
-        self.assertRaises(AttributeError, SwaggerClient,
+        self.assertRaises(AttributeError, SwaggerClient.from_url,
                           u'http://localhost/api-docs')
 
     @httpretty.activate
@@ -139,7 +139,7 @@ class ResourceOperationTest(unittest.TestCase):
         parameters = self.response["apis"][0]["operations"][0]["parameters"]
         parameters[0]["type"] = "WRONG_TYPE"
         self.register_urls()
-        self.assertRaises(SwaggerError, SwaggerClient,
+        self.assertRaises(SwaggerError, SwaggerClient.from_url,
                           u'http://localhost/api-docs')
 
     @httpretty.activate
@@ -148,7 +148,7 @@ class ResourceOperationTest(unittest.TestCase):
         parameters[0]["type"] = "array"
         parameters[0]["items"] = {"type": "WRONG_TYPE"}
         self.register_urls()
-        self.assertRaises(SwaggerError, SwaggerClient,
+        self.assertRaises(SwaggerError, SwaggerClient.from_url,
                           u'http://localhost/api-docs')
 
     @httpretty.activate
@@ -160,7 +160,7 @@ class ResourceOperationTest(unittest.TestCase):
             operations[0]["responseMessages"] = [msg]
             operations[0]["responseMessages"][0].pop(field)
             self.register_urls()
-            self.assertRaises(SwaggerError, SwaggerClient,
+            self.assertRaises(SwaggerError, SwaggerClient.from_url,
                               u'http://localhost/api-docs')
         [iterate_test(field) for field in ('code', 'message')]
 
@@ -187,7 +187,7 @@ class ResourceOperationTest(unittest.TestCase):
         self.register_urls()
         httpretty.register_uri(
             httpretty.POST, "http://localhost/test_http?", body='')
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resource.testHTTP(param_id=42, param_name='str').result()
         self.assertEqual('application/x-www-form-urlencoded',
                          httpretty.last_request().headers['content-type'])
@@ -212,7 +212,7 @@ class ResourceOperationTest(unittest.TestCase):
         self.register_urls()
         httpretty.register_uri(
             httpretty.POST, "http://localhost/test_http?", body='')
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         with open("test-data/1.2/simple/simple.json", "rb") as f:
             resource.testHTTP(param_id=42, file_name=f).result()
             content_type = httpretty.last_request().headers['content-type']
@@ -238,7 +238,7 @@ class ResourceOperationTest(unittest.TestCase):
             httpretty.GET,
             "http://localhost/params/42/test_http?test_param=foo",
             body='')
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resp = resource.testHTTP(test_param="foo", param_id="42").result()
         self.assertEqual(None, resp)
 
@@ -248,7 +248,7 @@ class ResourceOperationTest(unittest.TestCase):
         self.register_urls()
         httpretty.register_uri(httpretty.GET,
                                "http://localhost/test_http?", body='')
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resource.testHTTP().result()
         self.assertEqual(['testString'],
                          httpretty.last_request().querystring['test_param'])
@@ -272,7 +272,7 @@ class ResourceOperationTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET,
             "http://localhost/params/40,41,42/test_http?", body='')
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resp = resource.testHTTP(test_params=["foo", "bar"],
                                  param_ids=[40, 41, 42]).result()
         self.assertEqual(["foo", "bar"],
@@ -289,7 +289,7 @@ class ResourceOperationTest(unittest.TestCase):
         self.response["apis"][0]["operations"][0]["parameters"] = [
             query_parameter]
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         self.assertRaises(TypeError, resource.testHTTP,
                           test_param="NOT_INTEGER")
 
@@ -304,13 +304,13 @@ class ResourceOperationTest(unittest.TestCase):
         self.response["apis"][0]["operations"][0]["parameters"] = [
             query_parameter]
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         self.assertRaises(TypeError, resource.testHTTP, test_param=["A", "B"])
 
     @httpretty.activate
     def test_no_error_on_not_passing_non_required_param_in_query(self):
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         # No error should be raised on not passing test_param (not required)
         resource.testHTTP()
 
@@ -325,7 +325,7 @@ class ResourceOperationTest(unittest.TestCase):
         self.response["apis"][0]["operations"][0]["parameters"] = [
             query_parameter]
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         self.assertRaises(TypeError, resource.testHTTP,
                           test_param=["NOT_INTEGER"])
 
@@ -342,7 +342,7 @@ class ResourceOperationTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http", body='')
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         some_datetime = datetime.datetime(
             2014, 6, 10, 23, 49, 54, 728000, tzinfo=tzutc())
         resource.testHTTP(test_param=some_datetime).result()
@@ -362,7 +362,7 @@ class ResourceOperationTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http", body='')
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         some_date = datetime.date(2014, 6, 10)
         resource.testHTTP(test_param=some_date).result()
         self.assertEqual(['2014-06-10'],
@@ -391,7 +391,7 @@ class ResourceOperationTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.POST,
             "http://localhost/params/42/test_http?test_param=foo", body='')
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resp = resource.testHTTP(test_param="foo", param_id="42",
                                  body="some_test").result()
         self.assertEqual('some_test', httpretty.last_request().body)
@@ -413,7 +413,7 @@ class ResourceOperationTest(unittest.TestCase):
         self.register_urls()
         httpretty.register_uri(httpretty.POST, "http://localhost/test_http",
                                body='')
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resp = resource.testHTTP(body=["a", "b", "c"]).result()
         self.assertEqual(["a", "b", "c"],
                          json.loads(httpretty.last_request().body))

--- a/tests/resource_operation_test.py
+++ b/tests/resource_operation_test.py
@@ -46,7 +46,7 @@ A sample 'peration' is listed below in 'operations' list.
 """
 
 import datetime
-import json
+from swaggerpy.compat import json
 import unittest
 import urlparse
 

--- a/tests/resource_response_test.py
+++ b/tests/resource_response_test.py
@@ -137,7 +137,7 @@ class ResourceResponseTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http?test_param=foo",
             status=500)
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         self.assertRaises(HTTPError,
                           resource.testHTTP(test_param="foo").result)
 
@@ -149,7 +149,7 @@ class ResourceResponseTest(unittest.TestCase):
     def test_error_on_wrong_attr_type_in_operation_type(self):
         self.response["apis"][0]["operations"][0]["type"] = "WRONG_TYPE"
         self.register_urls()
-        self.assertRaises(SwaggerError, SwaggerClient,
+        self.assertRaises(SwaggerError, SwaggerClient.from_url,
                           u'http://localhost/api-docs')
 
     @httpretty.activate
@@ -167,7 +167,8 @@ class ResourceResponseTest(unittest.TestCase):
             httpretty.register_uri(
                 httpretty.GET, "http://localhost/test_http?test_param=foo",
                 body=types[type_])
-            resource = SwaggerClient(u'http://localhost/api-docs').api_test
+            resource = SwaggerClient.from_url(
+                u'http://localhost/api-docs').api_test
             resp = resource.testHTTP(test_param="foo").result()
             self.assertEqual(json.loads(types[type_]), resp)
 
@@ -185,7 +186,8 @@ class ResourceResponseTest(unittest.TestCase):
             httpretty.register_uri(
                 httpretty.GET, "http://localhost/test_http?test_param=foo",
                 body=types[type_])
-            resource = SwaggerClient(u'http://localhost/api-docs').api_test
+            resource = SwaggerClient.from_url(
+                u'http://localhost/api-docs').api_test
             future = resource.testHTTP(test_param="foo")
             self.assertRaises(TypeError, future)
 
@@ -196,7 +198,7 @@ class ResourceResponseTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http?test_param=foo",
             body='{"some_foo": "bar"}')
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resp = resource.testHTTP(test_param="foo").result()
         self.assertEqual({"some_foo": "bar"}, resp)
 
@@ -209,7 +211,7 @@ class ResourceResponseTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http?",
             body='{"some_foo": "bar"}')
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resp = resource.testHTTP(test_param="foo").result(raw_response=True)
         self.assertEqual({"some_foo": "bar"}, resp)
 
@@ -221,7 +223,7 @@ class ResourceResponseTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http?test_param=foo",
             body='"2014-06-10"')
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resp = resource.testHTTP(test_param="foo").result()
         self.assertEqual(resp, datetime.date(2014, 6, 10))
 
@@ -237,7 +239,7 @@ class ResourceResponseTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http?test_param=foo",
             body='["2014-06-10T23:49:54.728+0000"]')
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resp = resource.testHTTP(test_param="foo").result()
         self.assertEqual(resp, [datetime.datetime(
             2014, 6, 10, 23, 49, 54, 728000, tzinfo=tzutc())])
@@ -250,7 +252,7 @@ class ResourceResponseTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http?test_param=foo",
             body="123.32")
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         future = resource.testHTTP(test_param="foo")
         self.assertRaises(TypeError, future)
 
@@ -258,7 +260,7 @@ class ResourceResponseTest(unittest.TestCase):
     @httpretty.activate
     def test_future_is_returned_from_swagger_client(self):
         self.register_urls()
-        future = SwaggerClient(
+        future = SwaggerClient.from_url(
             u'http://localhost/api-docs').api_test.testHTTP(test_param="a")
         self.assertTrue(isinstance(future, HTTPFuture))
 

--- a/tests/resource_response_test.py
+++ b/tests/resource_response_test.py
@@ -55,7 +55,7 @@ is validated against its type 'Pet' which is defined like so:
 """
 
 import datetime
-import json
+from swaggerpy.compat import json
 import unittest
 from mock import patch, Mock
 

--- a/tests/resource_test.py
+++ b/tests/resource_test.py
@@ -65,7 +65,7 @@ class ResourceTest(unittest.TestCase):
     def test_error_on_wrong_swagger_version(self):
         self.response["swaggerVersion"] = "XYZ"
         self.register_urls()
-        self.assertRaises(SwaggerError, SwaggerClient,
+        self.assertRaises(SwaggerError, SwaggerClient.from_url,
                           u'http://localhost/api-docs')
 
     @httpretty.activate
@@ -73,7 +73,7 @@ class ResourceTest(unittest.TestCase):
         def iterate_test(field):
             self.response.pop(field)
             self.register_urls()
-            self.assertRaises(SwaggerError, SwaggerClient,
+            self.assertRaises(SwaggerError, SwaggerClient.from_url,
                               u'http://localhost/api-docs')
         [iterate_test(field) for field in (
             'swaggerVersion', 'basePath', 'apis')]
@@ -85,7 +85,7 @@ class ResourceTest(unittest.TestCase):
             httpretty.GET, "http://localhost/test_http?query=foo",
             body='[]')
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resp = resource.testHTTP(test_param="foo").result()
         self.assertEqual([], resp)
 
@@ -96,7 +96,7 @@ class ResourceTest(unittest.TestCase):
             httpretty.GET, "http://localhost/append/test_http?",
             body='[]')
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resource.testHTTP(test_param="foo").result()
         self.assertEqual(["foo"],
                          httpretty.last_request().querystring['test_param'])
@@ -104,14 +104,14 @@ class ResourceTest(unittest.TestCase):
     @httpretty.activate
     def test_setattrs_on_client_and_resource(self):
         self.register_urls()
-        client = SwaggerClient(u'http://localhost/api-docs')
+        client = SwaggerClient.from_url(u'http://localhost/api-docs')
         self.assertTrue(isinstance(client.api_test, Resource))
         self.assertTrue(isinstance(client.api_test.testHTTP, Operation))
 
     @httpretty.activate
     def test_headers_sendable_with_api_doc_request(self):
         self.register_urls()
-        SwaggerClient(
+        SwaggerClient.from_url(
             u'http://localhost/api-docs',
             api_doc_request_headers={'foot': 'bart'},
         )
@@ -127,8 +127,9 @@ class ResourceTest(unittest.TestCase):
             httpretty.GET, "http://foo/test_http?", body='')
         self.response["basePath"] = "http://localhost"
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs',
-                                 api_base_path='http://foo').api_test
+        resource = SwaggerClient.from_url(
+            u'http://localhost/api-docs',
+            api_base_path='http://foo').api_test
         resource.testHTTP(test_param="foo").result()
         self.assertEqual(["foo"],
                          httpretty.last_request().querystring['test_param'])
@@ -142,7 +143,7 @@ class ResourceTest(unittest.TestCase):
             body=u'""')
         self.response["basePath"] = "http://localhost/lame/test"
         self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
         resp = resource.testHTTP(test_param="foo").result()
         self.assertEqual('', resp)
 

--- a/tests/resource_test.py
+++ b/tests/resource_test.py
@@ -20,7 +20,7 @@ A sample 'resource' is listed below.
 }
 """
 
-import json
+from swaggerpy.compat import json
 import unittest
 
 import httpretty

--- a/tox.ini
+++ b/tox.ini
@@ -41,3 +41,4 @@ commands = sphinx-build -b html -d build/doctrees source build/html
 
 [flake8]
 exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,docs,virtualenv_run
+max_line_length = 80


### PR DESCRIPTION
Previously the entire process of fetching the api docs, validating the api docs, and building `Resources`/`Operations` was done as part of the constructor of `SwaggerClient`.  Constructors should never do anything more than assignment to fields.  Complex constructors are difficult to test, and make re-use more difficult. 

This branch splits the constructor into two factory methods `from_url()`, and `from_resource_listing()`.  This allows consumers to create a `SwaggerClient` from just a list of resources, which also removes the branch logic from the constructor. This is still backwards compatible because the only documented interface is the `get_client()` call. 

Some other things:
* use `simplejson` if it's available (since it's much faster, and this is very slow)
* completely removed the need for `ClientProcessor` (yay less inheritance!). This subclass was only being used for the single method that it implemented. All other operations are already done by default by the `Loader`. That method was extracted to `append_name_to_api()`.
* change the kwarg for the client cache to be `ttl` instead of `timeout` (`timeout` is still supported for backwards compatibility), and some other renames around the cache
* cache clients based on all args + kwargs, not just the first argument. All the arguments change the behaviour of the client, so they all need to be part of the key. Uses `repr()` instead of `json.dumps()`.
* `SwaggerClient` and `Resource` now support `dir()` (and tab completion in ipython) without `setattr` (which was duplicating the `__getattr__`).


Resolves #80. Remove special case for `datetime` in `stringify_body`. This should be totally unnecessary. The `swagger_model` should already convert this datetime into the proper format.

Resolves #76. Previously `api_base_path` was being used for two different things: overriding the default url that was specified in the swagger api doc, and also as a base url for swagger api docs that use relative urls.  I've split this into two params. `api_base_path` is now only an override, `base_url` is now the base url to append to relatives `basePath` urls.

Resolves #83. `raise_with` is unnecessary, and makes the interface for `swagger-py` more verbose than it needs to be.


Sorry this is so big. Most of this had to be changed all at once, so I wasn't able to break it into smaller parts. I did pull out a couple isolated commits, and a lot of this is just simple replacement (json imports, and test changes to use the new factories).