### PR TITLE
Lazy load model docstring

### DIFF
--- a/swaggerpy/swagger_model.py
+++ b/swaggerpy/swagger_model.py
@@ -308,7 +308,11 @@ class docstring_property(object):
 
 
 def create_model_type(model):
-    """creates a dynamic model from the model data present in the json
+    """Create a dynamic class from the model data defined in the swagger spec.
+
+    The docstring for this class is dynamically generated because generating
+    the docstring is relatively expensive, and would only be used in rare
+    cases for interactive debugging in a REPL.
 
     :param model: Resource model :class:`dict` with keys `id` and `properties`
     :returns: dynamic type created with attributes, docstrings attached

--- a/swaggerpy/swagger_model.py
+++ b/swaggerpy/swagger_model.py
@@ -1,21 +1,13 @@
 # -*- coding: utf-8 -*-
-
-#
-# Copyright (c) 2013, Digium, Inc.
-# Copyright (c) 2014, Yelp, Inc.
-#
-
-"""Code for handling the base Swagger API model.
-"""
-
+from copy import copy
+from functools import partial
 import logging
-from swaggerpy.compat import json
 import os
 import urllib
 import urlparse
-from copy import copy
 
-import swagger_type
+from swaggerpy import swagger_type
+from swaggerpy.compat import json
 from swaggerpy.http_client import SynchronousHttpClient
 from swaggerpy.processors import SwaggerProcessor, SwaggerError
 
@@ -307,35 +299,35 @@ def load_json(resource_listing, http_client=None, processors=None):
     return resource_listing
 
 
+class docstring_property(object):
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, _cls, _owner):
+        return self.func()
+
+
 def create_model_type(model):
     """creates a dynamic model from the model data present in the json
-       :param model: Resource Model json containing id, properties
-       :type model: dict
-       :returns: dynamic type created with attributes, docstrings attached
-       :rtype: type
+
+    :param model: Resource model :class:`dict` with keys `id` and `properties`
+    :returns: dynamic type created with attributes, docstrings attached
+    :rtype: type
     """
     props = model['properties']
     name = str(model['id'])
+
     methods = dict(
-        # Magic Methods :
-        # Define the docstring
-        __doc__=create_model_docstring(props),
-        # Make equality work for dict & type OR type & type
+        __doc__=docstring_property(partial(create_model_docstring, props)),
         __eq__=lambda self, other: compare(self, other),
-        # Define the constructor for the type
         __init__=lambda self, **kwargs: set_props(self, **kwargs),
-        # Define the str repr of the type
         __repr__=lambda self: create_model_repr(self),
-        # Instance methods :
-        # Generates flat dict from the model instance
-        _flat_dict=lambda self: create_flat_dict(self))
-    model_type = type(name, (object,), methods)
-    # Define a class variable to store types of its attributes
-    setattr(model_type, '_swagger_types',
-            swagger_type.get_swagger_types(props))
-    # Define a class variable to store all required fields
-    setattr(model_type, '_required', model.get('required'))
-    return model_type
+        __dir__=lambda self: props.keys(),
+        _flat_dict=lambda self: create_flat_dict(self),
+        _swagger_types=swagger_type.get_swagger_types(props),
+        _required=model.get('required'),
+    )
+    return type(name, (object,), methods)
 
 
 def set_props(model, **kwargs):

--- a/tests/resource_model_test.py
+++ b/tests/resource_model_test.py
@@ -145,13 +145,6 @@ class ResourceTest(unittest.TestCase):
     ################################################################
 
     @httpretty.activate
-    def test_success_on_model_types_creation(self):
-        self.register_urls()
-        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
-        User = resource.testHTTP._models['User']
-        self.assertEqual({"schools": [], "id": 0L}, User().__dict__)
-
-    @httpretty.activate
     def test_nones_for_dates_on_model_types_creation(self):
         self.models['User']['properties']['date'] = {
             'type': 'string',
@@ -166,19 +159,6 @@ class ResourceTest(unittest.TestCase):
             {"schools": [], "id": 0L, "date": None, "datetime": None},
             User().__dict__
         )
-
-    @httpretty.activate
-    def test_success_on_model_types_instantiation(self):
-        self.register_urls()
-        resource = SwaggerClient.from_url(u'http://localhost/api-docs').api_test
-        models = resource.testHTTP._models
-        User = models['User']
-        School = models['School']
-        user = User(id=42, schools=[School(name="a"), School(name="b")])
-        user1 = User(schools=[School(name="a"), School(name="b")], id=42)
-        self.assertEqual(user1, user)
-
-    # TODO: DocString generated is not validated as of now
 
     @httpretty.activate
     def test_error_on_wrong_attr_type_in_model_declaration(self):

--- a/tests/swagger_model_test.py
+++ b/tests/swagger_model_test.py
@@ -1,0 +1,51 @@
+
+import mock
+
+from swaggerpy import swagger_model
+
+
+class TestCreateModelType(object):
+
+    model = {
+        "id": "Pet",
+        "properties": {
+            "id": {
+                "type": "integer",
+                "format": "int64",
+                "description": "unique identifier for the pet",
+            },
+            "category": {
+                "$ref": "Category"
+            },
+            "name": {
+                "type": "string"
+            },
+            "status": {
+                "type": "string",
+                "description": "pet status in the store",
+            }
+        },
+        'required': ['id', 'category'],
+    }
+
+    def test_create_model_type(self):
+        model_type = swagger_model.create_model_type(self.model)
+        expected = set(['id', 'category', 'name', 'status'])
+        instance = model_type(status='ok')
+        assert set(vars(instance).keys()) == expected
+        assert set(dir(instance)) == expected
+        assert instance == model_type(id=0, name='', status='ok')
+        assert model_type._swagger_types == {
+            'id': 'integer:int64',
+            'category': 'Category',
+            'name': 'string',
+            'status': 'string',
+        }
+        assert model_type._required == ['id', 'category']
+
+    @mock.patch('swaggerpy.swagger_model.create_model_docstring', autospec=True)
+    def test_create_model_type_lazy_docstring(self, mock_create_docstring):
+        model_type = swagger_model.create_model_type(self.model)
+        assert not mock_create_docstring.called
+        assert model_type.__doc__ == mock_create_docstring.return_value
+        mock_create_docstring.assert_called_once_with(self.model['properties'])


### PR DESCRIPTION
Resolves the second point in #87

Based on https://github.com/prat0318/swagger-py/compare/Lazy_model_docstring

Added some unit tests for model building which replaced a couple of the integration tests.

I did some manual testing as well, to verify the ipython interactive behaviour works as expected, and that `create_model_docstring` is not in the cprofile for a regular non-interactive call.