### PR TITLE
Pin twisted >= 14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "crochet",
         "python-dateutil",
         "requests",
-        "twisted",
+        "twisted >= 14.0.0",
         "yelp_uri >= 1.0.1",
     ],
 )


### PR DESCRIPTION
Twisted versions `12.3.0` and `13.0.0` throw timeout error (tested manually). It seems to be fixed in Twisted version 14 and later. Fixes #118  