### PR TITLE
Add 'file' support to parameters

### DIFF
--- a/bravado/mapping/marshal.py
+++ b/bravado/mapping/marshal.py
@@ -42,7 +42,9 @@ def marshal_schema_object(swagger_spec, schema_object_spec, value):
     if obj_type == 'object':
         return marshal_object(swagger_spec, schema_object_spec, value)
 
-    # TODO: Support for 'file' type
+    if obj_type == 'file':
+        return value
+
     raise SwaggerMappingError('Unknown type {0} for value {1}'.format(
         obj_type, value))
 

--- a/bravado/mapping/operation.py
+++ b/bravado/mapping/operation.py
@@ -35,6 +35,18 @@ class Operation(object):
         # (key, value) = (param name, Param)
         self.params = {}
 
+    @property
+    def consumes(self):
+        """
+        :return: List of supported mime types consumed by this operation. e.g.
+            ["application/x-www-form-urlencoded"]
+        :rtype: list of strings, never None
+        """
+        result = self.op_spec.get('consumes')
+        if result is None:
+            result = self.swagger_spec.spec_dict.get('consumes', [])
+        return result
+
     @classmethod
     def from_spec(cls, swagger_spec, path_name, http_method, op_spec):
         """
@@ -63,7 +75,7 @@ class Operation(object):
         param_specs = op_param_specs + path_param_specs
 
         for param_spec in param_specs:
-            param = Param(self.swagger_spec, param_spec)
+            param = Param(self.swagger_spec, self, param_spec)
             self.params[param.name] = param
 
     @property

--- a/bravado/mapping/param.py
+++ b/bravado/mapping/param.py
@@ -121,9 +121,9 @@ def add_file(param, value, request):
     :param value: The raw content of the file to be uploaded
     :type request: dict
     """
-    if request.get('file') is None:
+    if request.get('files') is None:
         # support multiple files by default by setting to an empty array
-        request['file'] = []
+        request['files'] = []
 
         # The http client should take care of setting the content-type header
         # to 'multipart/form-data'. Just verify that the swagger spec is
@@ -139,8 +139,8 @@ def add_file(param, value, request):
                     param.op.consumes
                 ))
 
-    file_tuple = ('files', (param.name, value))
-    request['file'].append(file_tuple)
+    file_tuple = ('file', (param.name, value))
+    request['files'].append(file_tuple)
 
 
 def add_formdata(param, value, request):

--- a/bravado/mapping/param.py
+++ b/bravado/mapping/param.py
@@ -129,6 +129,8 @@ def add_file(param, value, request):
         # to 'multipart/form-data'. Just verify that the swagger spec is
         # conformant
         expected_mime_type = 'multipart/form-data'
+
+        # TODO: Remove after https://github.com/Yelp/swagger_spec_validator/issues/22 is implemented  # noqa
         if expected_mime_type not in param.op.consumes:
             raise SwaggerMappingError((
                 "Mime-type '{0}' not found in list of supported mime-types for "

--- a/bravado/mapping/param.py
+++ b/bravado/mapping/param.py
@@ -1,5 +1,4 @@
 import urllib
-from bravado.mapping import schema
 import simplejson as json
 
 from bravado.mapping.exception import SwaggerMappingError
@@ -143,7 +142,12 @@ def add_file(param, value, request):
 
 
 def add_formdata(param, value, request):
-    # form parameter
+    """Add a parameter as formdata to the given request.
+
+    :type param: :class;`bravado.mapping.param.Param`
+    :param value: parameter value
+    :type request: dict
+    """
     if request.get('data') is None:
         request['data'] = {}
     request['data'][param.name] = value

--- a/bravado/mapping/param.py
+++ b/bravado/mapping/param.py
@@ -61,13 +61,15 @@ def get_param_type_spec(param):
 
     :rtype: dict
     :return: the param spec that contains 'type'
+    :raises: SwaggerMappingError when param location is not valid
     """
     location = param.location
     if location in ('path', 'query', 'header', 'formData'):
         return param.param_spec
     if location == 'body':
         return param.param_spec['schema']
-    raise Exception("Don't know how to handle location {0}".format(location))
+    raise SwaggerMappingError(
+        "Don't know how to handle location {0}".format(location))
 
 
 def marshal_param(param, value, request):

--- a/bravado/mapping/param.py
+++ b/bravado/mapping/param.py
@@ -104,7 +104,7 @@ def marshal_param(param, value, request):
         if spec['type'] == 'file':
             add_file(param, value, request)
         else:
-            add_formdata(param, value, request)
+            request.setdefault('data', {})[param.name] = value
     elif location == 'body':
         request['headers']['Content-Type'] = APP_JSON
         request['data'] = json.dumps(value)
@@ -143,15 +143,3 @@ def add_file(param, value, request):
 
     file_tuple = ('file', (param.name, value))
     request['files'].append(file_tuple)
-
-
-def add_formdata(param, value, request):
-    """Add a parameter as formdata to the given request.
-
-    :type param: :class;`bravado.mapping.param.Param`
-    :param value: parameter value
-    :type request: dict
-    """
-    if request.get('data') is None:
-        request['data'] = {}
-    request['data'][param.name] = value

--- a/tests/mapping/operation/consumes_test.py
+++ b/tests/mapping/operation/consumes_test.py
@@ -1,0 +1,44 @@
+from bravado.mapping.operation import Operation
+from bravado.mapping.spec import Spec
+
+
+def test_returns_consumes_from_op(minimal_swagger_dict):
+    op_spec = {
+        'consumes': ['multipart/form-data']
+    }
+    minimal_swagger_spec = Spec.from_dict(minimal_swagger_dict)
+    op = Operation(minimal_swagger_spec, '/foo', 'get', op_spec)
+    assert ['multipart/form-data'] == op.consumes
+
+
+def test_returns_consumes_from_swagger_spec_when_not_present_on_op(
+        minimal_swagger_dict):
+    op_spec = {
+        # 'consumes' left out intentionally
+    }
+    minimal_swagger_dict['consumes'] = ['multipart/form-data']
+    minimal_swagger_spec = Spec.from_dict(minimal_swagger_dict)
+    op = Operation(minimal_swagger_spec, '/foo', 'get', op_spec)
+    assert ['multipart/form-data'] == op.consumes
+
+
+def test_consumes_on_op_overrides_consumes_from_swagger_spec(
+        minimal_swagger_dict):
+    op_spec = {
+        'consumes': ['application/x-www-form-urlencoded']
+    }
+    minimal_swagger_dict['consumes'] = ['multipart/form-data']
+    minimal_swagger_spec = Spec.from_dict(minimal_swagger_dict)
+    op = Operation(minimal_swagger_spec, '/foo', 'get', op_spec)
+    assert ['application/x-www-form-urlencoded'] == op.consumes
+
+
+def test_consumes_not_present_on_swagger_spec_returns_empty_array(
+        minimal_swagger_dict):
+    # The point being, None should never be returned
+    op_spec = {
+        # 'consumes' left out intentionally
+    }
+    minimal_swagger_spec = Spec.from_dict(minimal_swagger_dict)
+    op = Operation(minimal_swagger_spec, '/foo', 'get', op_spec)
+    assert [] == op.consumes

--- a/tests/mapping/param/add_file_test.py
+++ b/tests/mapping/param/add_file_test.py
@@ -1,0 +1,67 @@
+from bravado.mapping.exception import SwaggerMappingError
+from mock import Mock
+import pytest
+
+from bravado.mapping.operation import Operation
+from bravado.mapping.param import add_file, Param
+
+
+def test_single_file(empty_swagger_spec):
+    request = {}
+    file_contents = "I am the contents of a file"
+    op = Mock(spec=Operation, consumes=['multipart/form-data'])
+    param_spec = {
+        'type': 'file',
+        'in': 'formData',
+        'name': 'photo'
+    }
+    param = Param(empty_swagger_spec, op, param_spec)
+    add_file(param, file_contents, request)
+    expected_request = {
+        'file': [('files', ('photo', 'I am the contents of a file'))]
+    }
+    assert expected_request == request
+
+
+def test_multiple_files(empty_swagger_spec):
+    request = {}
+    file1_contents = "I am the contents of a file1"
+    file2_contents = "I am the contents of a file2"
+    op = Mock(spec=Operation, consumes=['multipart/form-data'])
+    param1_spec = {
+        'type': 'file',
+        'in': 'formData',
+        'name': 'photo'
+    }
+    param2_spec = {
+        'type': 'file',
+        'in': 'formData',
+        'name': 'headshot'
+    }
+
+    param1 = Param(empty_swagger_spec, op, param1_spec)
+    param2 = Param(empty_swagger_spec, op, param2_spec)
+    add_file(param1, file1_contents, request)
+    add_file(param2, file2_contents, request)
+    expected_request = {
+        'file': [
+            ('files', ('photo', 'I am the contents of a file1')),
+            ('files', ('headshot', 'I am the contents of a file2')),
+        ]
+    }
+    assert expected_request == request
+
+
+def test_mime_type_not_found_in_consumes(empty_swagger_spec):
+    request = {}
+    file_contents = "I am the contents of a file"
+    op = Mock(spec=Operation, operation_id='upload_photos', consumes=[])
+    param_spec = {
+        'type': 'file',
+        'in': 'formData',
+        'name': 'photo'
+    }
+    param = Param(empty_swagger_spec, op, param_spec)
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        add_file(param, file_contents, request)
+    assert "not found in list of supported mime-types" in str(excinfo.value)

--- a/tests/mapping/param/add_file_test.py
+++ b/tests/mapping/param/add_file_test.py
@@ -1,7 +1,7 @@
-from bravado.mapping.exception import SwaggerMappingError
 from mock import Mock
 import pytest
 
+from bravado.mapping.exception import SwaggerMappingError
 from bravado.mapping.operation import Operation
 from bravado.mapping.param import add_file, Param
 
@@ -18,7 +18,7 @@ def test_single_file(empty_swagger_spec):
     param = Param(empty_swagger_spec, op, param_spec)
     add_file(param, file_contents, request)
     expected_request = {
-        'file': [('files', ('photo', 'I am the contents of a file'))]
+        'files': [('file', ('photo', 'I am the contents of a file'))]
     }
     assert expected_request == request
 
@@ -44,9 +44,9 @@ def test_multiple_files(empty_swagger_spec):
     add_file(param1, file1_contents, request)
     add_file(param2, file2_contents, request)
     expected_request = {
-        'file': [
-            ('files', ('photo', 'I am the contents of a file1')),
-            ('files', ('headshot', 'I am the contents of a file2')),
+        'files': [
+            ('file', ('photo', 'I am the contents of a file1')),
+            ('file', ('headshot', 'I am the contents of a file2')),
         ]
     }
     assert expected_request == request

--- a/tests/mapping/param/get_param_type_spec_test.py
+++ b/tests/mapping/param/get_param_type_spec_test.py
@@ -1,5 +1,7 @@
+from mock import Mock
 import pytest
 
+from bravado.mapping.operation import Operation
 from bravado.mapping.param import Param, get_param_type_spec
 
 
@@ -13,7 +15,7 @@ def test_location_is_body(empty_swagger_spec):
             'type': 'string'
         }
     }
-    param = Param(empty_swagger_spec, param_spec)
+    param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
     assert param_spec['schema'] == get_param_type_spec(param)
 
 
@@ -26,7 +28,7 @@ def test_location_is_not_body(empty_swagger_spec):
             'required': True,
             'type': 'string',
         }
-        param = Param(empty_swagger_spec, param_spec)
+        param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
         assert param_spec == get_param_type_spec(param)
 
 
@@ -34,7 +36,7 @@ def test_location_unknown(empty_swagger_spec):
     param_spec = {
         'in': 'foo',
     }
-    param = Param(empty_swagger_spec, param_spec)
+    param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
 
     with pytest.raises(Exception) as excinfo:
         get_param_type_spec(param)

--- a/tests/mapping/param/get_param_type_spec_test.py
+++ b/tests/mapping/param/get_param_type_spec_test.py
@@ -1,3 +1,4 @@
+from bravado.mapping.exception import SwaggerMappingError
 from mock import Mock
 import pytest
 
@@ -38,6 +39,6 @@ def test_location_unknown(empty_swagger_spec):
     }
     param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
 
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(SwaggerMappingError) as excinfo:
         get_param_type_spec(param)
     assert 'location foo' in str(excinfo)

--- a/tests/mapping/param/marshal_param_test.py
+++ b/tests/mapping/param/marshal_param_test.py
@@ -121,6 +121,6 @@ def test_formData_file(empty_swagger_spec, param_spec, request_dict):
     marshal_param(param, "i am the contents of a file", request_dict)
     expected = {
         'params': {},
-        'file': [('files', ('petId', "i am the contents of a file"))],
+        'files': [('file', ('petId', "i am the contents of a file"))],
     }
     assert expected == request_dict

--- a/tests/mapping/param/marshal_param_test.py
+++ b/tests/mapping/param/marshal_param_test.py
@@ -123,5 +123,4 @@ def test_formData_file(empty_swagger_spec, param_spec, request_dict):
         'params': {},
         'file': [('files', ('petId', "i am the contents of a file"))],
     }
-    print request_dict
     assert expected == request_dict

--- a/tests/mapping/param/marshal_param_test.py
+++ b/tests/mapping/param/marshal_param_test.py
@@ -1,7 +1,9 @@
+from mock import Mock
 import pytest
 
 from bravado.http_client import APP_JSON
 from bravado.mapping.param import Param, marshal_param
+from bravado.mapping.operation import Operation
 
 
 @pytest.fixture
@@ -45,7 +47,7 @@ def param_spec():
 
 
 def test_query_string(empty_swagger_spec, string_param_spec, request_dict):
-    param = Param(empty_swagger_spec, string_param_spec)
+    param = Param(empty_swagger_spec, Mock(spec=Operation), string_param_spec)
     expected = request_dict.copy()
     expected['params']['username'] = 'darwin'
     marshal_param(param, 'darwin', request_dict)
@@ -53,7 +55,7 @@ def test_query_string(empty_swagger_spec, string_param_spec, request_dict):
 
 
 def test_query_array(empty_swagger_spec, array_param_spec, request_dict):
-    param = Param(empty_swagger_spec, array_param_spec)
+    param = Param(empty_swagger_spec, Mock(spec=Operation), array_param_spec)
     value = ['cat', 'dog', 'bird']
     expected = request_dict.copy()
     expected['params']['animals'] = value
@@ -63,7 +65,7 @@ def test_query_array(empty_swagger_spec, array_param_spec, request_dict):
 
 def test_path_string(empty_swagger_spec, param_spec):
     param_spec['in'] = 'path'
-    param = Param(empty_swagger_spec, param_spec)
+    param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
     request = {'url': '/pet/{petId}'}
     marshal_param(param, 34, request)
     assert '/pet/34' == request['url']
@@ -73,7 +75,7 @@ def test_header_string(empty_swagger_spec, param_spec):
     param_spec['in'] = 'header'
     param_spec['type'] = 'string'
     del param_spec['format']
-    param = Param(empty_swagger_spec, param_spec)
+    param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
     request = {
         'headers': {}
     }
@@ -88,7 +90,7 @@ def test_body(empty_swagger_spec, param_spec):
     }
     del param_spec['type']
     del param_spec['format']
-    param = Param(empty_swagger_spec, param_spec)
+    param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
     request = {
         'headers': {
         }
@@ -98,12 +100,28 @@ def test_body(empty_swagger_spec, param_spec):
     assert APP_JSON == request['headers']['Content-Type']
 
 
-def test_formData(empty_swagger_spec, param_spec):
+def test_formData_integer(empty_swagger_spec, param_spec):
     param_spec['in'] = 'formData'
-    param = Param(empty_swagger_spec, param_spec)
+    param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
     request = {
         'headers': {
         }
     }
     marshal_param(param, 34, request)
     assert 34 == request['data']['petId']
+
+
+def test_formData_file(empty_swagger_spec, param_spec, request_dict):
+    param_spec['in'] = 'formData'
+    param_spec['type'] = 'file'
+    param = Param(
+        empty_swagger_spec,
+        Mock(spec=Operation, consumes=['multipart/form-data']),
+        param_spec)
+    marshal_param(param, "i am the contents of a file", request_dict)
+    expected = {
+        'params': {},
+        'file': [('files', ('petId', "i am the contents of a file"))],
+    }
+    print request_dict
+    assert expected == request_dict

--- a/tests/petstore/pet/uploadFile_test.py
+++ b/tests/petstore/pet/uploadFile_test.py
@@ -1,7 +1,10 @@
-import pytest
 
-
-@pytest.xfail.mark(reason="Get in:formData and type:file working")
 def test_success(petstore):
-    result = petstore.pet.uploadFile().result()
+    contents = "this is supposed to be a file"
+    print len(contents)
+    status, result = petstore.pet.uploadFile(
+        petId=1,
+        file=contents,
+        additionalMetadata="testing file upload").result()
+    print status
     print result


### PR DESCRIPTION
Useful documentation for the Requests lib on file support - http://docs.python-requests.org/en/latest/user/advanced/#post-multiple-multipart-encoded-files