### PR TITLE
Remove caching from the client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ Example Usage
 .. code:: Python
 
     from bravado.client import SwaggerClient
-    swagger_client = SwaggeClient.from_url("http://petstore.swagger.wordnik.com/api/api-docs")
-    status, pet = swagger_client.pet.getPetById(petId=42).result()
+    client = SwaggerClient.from_url("http://petstore.swagger.wordnik.com/api/api-docs")
+    status, pet = client.pet.getPetById(petId=42).result()
 
 Documentation
 -------------

--- a/README.rst
+++ b/README.rst
@@ -27,9 +27,9 @@ Example Usage
 
 .. code:: Python
 
-    from bravado import client
-    swagger_client = client.get_client("http://petstore.swagger.wordnik.com/api/api-docs")
-    swagger_client.pet.getPetById(petId=42).result()
+    from bravado.client import SwaggerClient
+    swagger_client = SwaggeClient.from_url("http://petstore.swagger.wordnik.com/api/api-docs")
+    status, pet = swagger_client.pet.getPetById(petId=42).result()
 
 Documentation
 -------------

--- a/bravado/client.py
+++ b/bravado/client.py
@@ -45,14 +45,11 @@ To get a client
 """
 
 import logging
-import time
 
 from bravado.http_client import SynchronousHttpClient
-from bravado.swagger_model import (
-    Loader,
-    is_file_scheme_uri,
-)
 from bravado.mapping.spec import Spec
+from bravado.swagger_model import Loader
+
 
 log = logging.getLogger(__name__)
 

--- a/bravado/client.py
+++ b/bravado/client.py
@@ -6,11 +6,11 @@ API response.
 
 Structure Diagram::
 
-        +---------------------+           +---------------------+
-        |                     |           |                     |
-        |    SwaggerClient    <-----------+  SwaggerClientCache |
-        |                     |   caches  |                     |
-        +------+--------------+           +---------------------+
+        +---------------------+
+        |                     |
+        |    SwaggerClient    |
+        |                     |
+        +------+--------------+
                |
                |  has many
                |
@@ -37,18 +37,11 @@ Structure Diagram::
         +---------------------+
 
 
-To get a client with caching
+To get a client
 
 .. code-block:: python
 
-        client = bravado.client.get_client(api_docs_url)
-
-without caching
-
-.. code-block:: python
-
-        client = bravado.client.SwaggerClient.from_url(api_docs_url)
-
+        client = bravado.client.SwaggerClient.from_url(swagger_spec_url)
 """
 
 import logging
@@ -63,112 +56,15 @@ from bravado.mapping.spec import Spec
 
 log = logging.getLogger(__name__)
 
-SWAGGER_SPEC_CACHE_TTL = 300
-
-
-class CacheEntry(object):
-    """An entry in the cache. Each item has it's own ttl.
-
-    :param item: the item to cache
-    :param ttl: time-to-live in seconds after which the client expires
-    :type  ttl: int
-    """
-
-    def __init__(self, item, ttl, timestamp=None):
-        self.item = item
-        self.ttl = ttl
-        self.timestamp = timestamp or time.time()
-
-    def is_stale(self, timestamp=None):
-        """Checks if the instance has become stale
-        :return: True if the cache item is stale, False otherwise
-        """
-        current_time = timestamp or time.time()
-        return self.timestamp + self.ttl < current_time
-
-
-class SwaggerClientCache(object):
-    """Cache to store swagger clients and refetch the api-docs if the client
-    becomes stale
-    """
-
-    def __init__(self):
-        self.cache = dict()
-
-    def __contains__(self, key):
-        return key in self.cache and not self.cache[key].is_stale()
-
-    def __call__(self, *args, **kwargs):
-        # timeout is backwards compatible with 0.7
-        ttl = kwargs.pop('ttl', kwargs.pop('timeout', SWAGGER_SPEC_CACHE_TTL))
-        key = repr(args) + repr(sorted(kwargs.iteritems()))
-
-        if key not in self:
-            self.cache[key] = CacheEntry(
-                self.build_client(*args, **kwargs), ttl)
-
-        return self.cache[key].item
-
-    def build_client(self, spec_url_or_dict, *args, **kwargs):
-        if isinstance(spec_url_or_dict, basestring):
-            return SwaggerClient.from_url(spec_url_or_dict, *args, **kwargs)
-        return SwaggerClient.from_spec(spec_url_or_dict, *args, **kwargs)
-
-
-cache = None
-
-
-def get_client(*args, **kwargs):
-    """Factory method to generate SwaggerClient instance.
-
-    .. note::
-
-        This factory method uses a global which maintains the state of swagger
-        client. Use :class:`SwaggerClientCache` if you want more control.
-
-    To change the freshness timeout, simply pass an argument: ttl=<seconds>
-
-    To remove the caching functionality, pass: ttl=0
-
-    .. note::
-
-       It is OKAY to call get_swagger_client(...) again and again.
-       Do not keep a reference to the generated client and make it long
-       lived as it strips out the refetching functionality.
-
-    :param api_docs_url: url for swagger api docs used to build the client
-    :type  api_docs_url: str
-    :param ttl: (optional) Timeout in secs. after which api-docs is stale
-    :return: :class:`SwaggerClient`
-    """
-    global cache
-
-    if cache is None:
-        cache = SwaggerClientCache()
-
-    return cache(*args, **kwargs)
-
-
-def get_resource_url(base_path, url_base, resource_base_path):
-    if base_path:
-        return base_path
-
-    if url_base and resource_base_path.startswith('/'):
-        if is_file_scheme_uri(url_base):
-            raise AssertionError("Can't resolve relative resource urls with a "
-                                 " file:// url, for %s." % resource_base_path)
-        return url_base.rstrip('/') + resource_base_path
-
-    return resource_base_path
-
 
 class SwaggerClient(object):
     """A client for accessing a Swagger-documented RESTful service.
-
-    :param swagger_spec: :class:`bravado.mapping.spec.Spec`
     """
 
     def __init__(self, swagger_spec):
+        """
+        :param swagger_spec: :class:`bravado.mapping.spec.Spec`
+        """
         self.swagger_spec = swagger_spec
 
     @classmethod

--- a/bravado/mapping/docstring.py
+++ b/bravado/mapping/docstring.py
@@ -25,7 +25,7 @@ def operation_docstring_wrapper(operation):
     to be masquaraded as a function. The docstring will then be attached to the
     function which works quite nicely. Example in REPL:
 
-    >> petstore = client.get_client('http://url_to_petstore/')
+    >> petstore = SwaggerClient.from_url('http://url_to_petstore/')
     >> pet = petstore.pet
     >> help(pet.getPetById)
 

--- a/bravado/mapping/validate.py
+++ b/bravado/mapping/validate.py
@@ -23,7 +23,9 @@ def validate_schema_object(spec, value):
     elif obj_type == 'object':
         validate_object(spec, value)
 
-    # TODO: Support for 'file' type
+    elif obj_type == 'file':
+        pass
+
     else:
         raise SwaggerMappingError('Unknown type {0} for value {1}'.format(
             obj_type, value))

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -4,119 +4,17 @@ import unittest
 
 import httpretty
 import requests
-from mock import patch
 import pytest
 
-from bravado import client
-from bravado.async_http_client import AsynchronousHttpClient
-from bravado.client import (
-    SwaggerClient,
-    SwaggerClientCache,
-)
-
-
-class SwaggerClientCacheTest(unittest.TestCase):
-
-    def setUp(self):
-        client.cache = None
-
-    tearDown = setUp
-
-    def test_is_stale_returns_true_after_ttl(self):
-        with patch('bravado.client.SwaggerClient'):
-            with patch('bravado.client.time.time', side_effect=[1]):
-                client.get_client('test', ttl=10)
-                assert client.cache.cache["('test',)[]"].is_stale(12)
-
-    def test_is_stale_returns_false_before_ttl(self):
-        with patch('bravado.client.SwaggerClient'):
-            with patch('bravado.client.time.time', side_effect=[1]):
-                client.get_client('test', ttl=10)
-                assert not client.cache.cache["('test',)[]"].is_stale(11)
-
-    def test_build_cached_item_with_proper_values(self):
-        with patch('bravado.client.SwaggerClient.from_url') as mock:
-            mock.return_value = 'foo'
-            with patch('bravado.client.time.time',
-                       side_effect=[1, 1]):
-                cache = SwaggerClientCache()
-                client_object = client.CacheEntry(
-                    cache.build_client('test'), 3)
-                self.assertEqual('foo', client_object.item)
-                self.assertEqual(3, client_object.ttl)
-                self.assertEqual(1, client_object.timestamp)
-
-    def test_builds_client_if_not_present_in_cache(self):
-        with patch('bravado.client.SwaggerClient.from_url') as mock:
-            with patch('bravado.client.time.time', side_effect=[1]):
-                client.get_client('foo')
-                mock.assert_called_once_with('foo')
-
-    def test_builds_client_if_present_in_cache_but_stale(self):
-        with patch('bravado.client.time.time', side_effect=[2, 3]):
-            client.cache = client.SwaggerClientCache()
-            client.cache.cache['foo'] = client.CacheEntry('bar', 0, 1)
-            with patch('bravado.client.SwaggerClient.from_url') as mock:
-                client.get_client('foo')
-                mock.assert_called_once_with('foo')
-
-    def test_uses_the_cache_if_present_and_fresh(self):
-        client.cache = client.SwaggerClientCache()
-        client.cache.cache['foo'] = client.CacheEntry('bar', 2, 1)
-        with patch('bravado.client.SwaggerClient') as mock:
-            with patch('bravado.client.time.time', side_effect=[2]):
-                client.get_client('foo')
-                assert not mock.called
-
-    @pytest.mark.xfail
-    @patch('bravado.client.Loader', autospec=True)
-    def test_cache_with_async_http_client(self, _):
-        url = 'http://example.com/api-docs'
-        swagger_client = client.get_client(
-            url,
-            http_client=AsynchronousHttpClient())
-        other = client.get_client(url, http_client=AsynchronousHttpClient())
-        assert swagger_client is other
-
-
-class GetClientMethodTest(unittest.TestCase):
-
-    def setUp(self):
-        client.cache = None
-
-    tearDown = setUp
-
-    def test_get_client_gets_atleast_one_param(self):
-        self.assertRaises(TypeError, client.get_client)
-
-    def test_get_client_instantiates_new_factory_if_not_set(self):
-        with patch.object(SwaggerClientCache, '__call__') as mock_method:
-            mock_method.client.return_value = None
-            client.get_client()
-            self.assertTrue(client.cache is not None)
-
-    def test_get_client_uses_instantiated_factory_second_time(self):
-        with patch.object(SwaggerClientCache, '__call__') as mock_method:
-            mock_method.client.return_value = None
-            client.cache = SwaggerClientCache()
-            prev_factory = client.cache
-            client.get_client()
-            self.assertTrue(prev_factory is client.cache)
-
-    @pytest.mark.xfail
-    def test_cache_of_a_json_dict(self):
-        client.get_client({'swaggerVersion': '1.2', 'apis': []})
-        self.assertTrue(
-            repr(({'swaggerVersion': '1.2', 'apis': []},)) + "[]" in
-            client.cache.cache)
+from bravado.client import SwaggerClient
 
 
 @pytest.mark.xfail
-class ClientTest(unittest.TestCase):
+class SwaggerClientTest(unittest.TestCase):
 
-    def test_get_client_allows_json_dict(self):
-        client_stub = client.get_client(self.resource_listing)
-        self.assertTrue(isinstance(client_stub, client.SwaggerClient))
+    def test_from_dict(self):
+        client_stub = SwaggerClient.from_dict(self.resource_listing)
+        assert isinstance(client_stub, SwaggerClient)
 
     @httpretty.activate
     def test_bad_operation(self):

--- a/tests/petstore/conftest.py
+++ b/tests/petstore/conftest.py
@@ -1,8 +1,8 @@
 import pytest
 
-from bravado import client
+from bravado.client import SwaggerClient
 
-
+# TODO: remove
 if False:
     import logging
     logging.basicConfig()
@@ -11,4 +11,4 @@ if False:
 
 @pytest.fixture
 def petstore():
-    return client.get_client('http://petstore.swagger.io/v2/swagger.json')
+    return SwaggerClient.from_url('http://petstore.swagger.io/v2/swagger.json')


### PR DESCRIPTION
We've talked about doing this previously. Caching is hard and something the client needs to be able to reason about to be implemented correctly.