### PR TITLE
Patch to allow POST with binary file in python 2.7

### DIFF
--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -180,7 +180,7 @@ class Operation(object):
         request = {}
         # The requests library expects native strings. Without this, POST
         # with a binary file upload throws a UnicodeDecodeError.
-        request['method'] = str(self._json[u'method'])
+        request['method'] = self._json[u'method'].encode('utf8')
         request['url'] = self._uri
         request['params'] = {}
         request['headers'] = _request_options.get('headers', {}) or {}

--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -178,6 +178,8 @@ class Operation(object):
         _request_options = kwargs.pop('_request_options', {}) or {}
 
         request = {}
+        # The requests library expects native strings. Without this, POST
+        # with a binary file upload throws a UnicodeDecodeError.
         request['method'] = str(self._json[u'method'])
         request['url'] = self._uri
         request['params'] = {}

--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -178,7 +178,7 @@ class Operation(object):
         _request_options = kwargs.pop('_request_options', {}) or {}
 
         request = {}
-        request['method'] = self._json[u'method']
+        request['method'] = str(self._json[u'method'])
         request['url'] = self._uri
         request['params'] = {}
         request['headers'] = _request_options.get('headers', {}) or {}

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -261,113 +261,113 @@ class ClientTest(unittest.TestCase):
     def setUp(self):
         # Default handlers for all swagger.py access
         self.resource_listing = {
-            "swaggerVersion": "1.2",
-            "basePath": "http://swagger.py/swagger-test",
-            "apis": [
+            u"swaggerVersion": u"1.2",
+            u"basePath": u"http://swagger.py/swagger-test",
+            u"apis": [
                 {
-                    "path": "/api-docs/pet.json",
-                    "description": "Test loader when missing a file",
-                    "api_declaration": {
-                        "swaggerVersion": "1.2",
-                        "basePath": "http://swagger.py/swagger-test",
-                        "resourcePath": "/pet.json",
-                        "apis": [
+                    u"path": u"/api-docs/pet.json",
+                    u"description": u"Test loader when missing a file",
+                    u"api_declaration": {
+                        u"swaggerVersion": u"1.2",
+                        u"basePath": u"http://swagger.py/swagger-test",
+                        u"resourcePath": u"/pet.json",
+                        u"apis": [
                             {
-                                "path": "/pet",
-                                "operations": [
+                                u"path": u"/pet",
+                                u"operations": [
                                     {
-                                        "method": "GET",
-                                        "nickname": "listPets",
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
+                                        u"method": u"GET",
+                                        u"nickname": u"listPets",
+                                        u"type": u"array",
+                                        u"items": {
+                                            u"type": u"string"
                                         },
-                                        "parameters": []
+                                        u"parameters": []
                                     },
                                     {
-                                        "method": "POST",
-                                        "nickname": "createPet",
-                                        "type": "string",
-                                        "parameters": [
+                                        u"method": u"POST",
+                                        u"nickname": u"createPet",
+                                        u"type": u"string",
+                                        u"parameters": [
                                             {
-                                                "name": "name",
-                                                "paramType": "query",
-                                                "type": "string",
-                                                "required": True
+                                                u"name": u"name",
+                                                u"paramType": u"query",
+                                                u"type": u"string",
+                                                u"required": True
                                             },
                                             {
-                                                "name": "birthday",
-                                                "paramType": "query",
-                                                "type": "string",
-                                                "format": "date",
-                                                "required": False
+                                                u"name": u"birthday",
+                                                u"paramType": u"query",
+                                                u"type": u"string",
+                                                u"format": u"date",
+                                                u"required": False
                                             }
                                         ]
                                     }
                                 ]
                             },
                             {
-                                "path": "/pet/find",
-                                "operations": [
+                                u"path": u"/pet/find",
+                                u"operations": [
                                     {
-                                        "method": "GET",
-                                        "nickname": "findPets",
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
+                                        u"method": u"GET",
+                                        u"nickname": u"findPets",
+                                        u"type": u"array",
+                                        u"items": {
+                                            u"type": u"string"
                                         },
-                                        "parameters": [
+                                        u"parameters": [
                                             {
-                                                "name": "species",
-                                                "paramType": "query",
-                                                "type": "string",
-                                                "allowMultiple": True
+                                                u"name": u"species",
+                                                u"paramType": u"query",
+                                                u"type": u"string",
+                                                u"allowMultiple": True
                                             }
                                         ]
                                     }
                                 ]
                             },
                             {
-                                "path": "/pet/{petId}",
-                                "operations": [
+                                u"path": u"/pet/{petId}",
+                                u"operations": [
                                     {
-                                        "method": "DELETE",
-                                        "nickname": "deletePet",
-                                        "type": "void",
-                                        "parameters": [
+                                        u"method": u"DELETE",
+                                        u"nickname": u"deletePet",
+                                        u"type": u"void",
+                                        u"parameters": [
                                             {
-                                                "name": "petId",
-                                                "type": "integer",
-                                                "paramType": "path"
+                                                u"name": u"petId",
+                                                u"type": u"integer",
+                                                u"paramType": u"path"
                                             }
                                         ]
                                     }
                                 ]
                             },
                             {
-                                "path": "/pet/{petId}/vaccine",
-                                "operations": [
+                                u"path": u"/pet/{petId}/vaccine",
+                                u"operations": [
                                     {
-                                        "method": u"POST",
-                                        "nickname": "postVaccine",
-                                        "type": "void",
-                                        "parameters": [
+                                        u"method": u"POST",
+                                        u"nickname": u"postVaccine",
+                                        u"type": u"void",
+                                        u"parameters": [
                                             {
-                                                "name": "petId",
-                                                "type": "integer",
-                                                "paramType": "path"
+                                                u"name": u"petId",
+                                                u"type": u"integer",
+                                                u"paramType": u"path"
                                             },
                                             {
-                                                "name": "vaccineFile",
-                                                "type": "File",
-                                                "paramType": "form"
+                                                u"name": u"vaccineFile",
+                                                u"type": u"File",
+                                                u"paramType": u"form"
                                             }
                                         ]
                                     }
                                 ]
                             }
                         ],
-                        "models": {}
+                        u"models": {}
                     }
                 }
             ]

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
+import tempfile
 import unittest
 
 import httpretty
@@ -235,6 +236,20 @@ class ClientTest(unittest.TestCase):
                          httpretty.last_request().querystring)
 
     @httpretty.activate
+    def test_post_binary_data(self):
+        httpretty.register_uri(
+            httpretty.POST, 'http://swagger.py/swagger-test/pet/1234/vaccine',
+            status=requests.codes.no_content)
+
+        temporary_file = tempfile.TemporaryFile()
+        temporary_file.write('\xff\xd8')
+        temporary_file.seek(0)
+
+        resp = self.uut.pet.postVaccine(
+            vaccineFile=temporary_file, petId=1234).result()
+        self.assertEqual(None, resp)
+
+    @httpretty.activate
     def test_delete(self):
         httpretty.register_uri(
             httpretty.DELETE, "http://swagger.py/swagger-test/pet/1234",
@@ -324,6 +339,28 @@ class ClientTest(unittest.TestCase):
                                                 "name": "petId",
                                                 "type": "integer",
                                                 "paramType": "path"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "path": "/pet/{petId}/vaccine",
+                                "operations": [
+                                    {
+                                        "method": u"POST",
+                                        "nickname": "postVaccine",
+                                        "type": "void",
+                                        "parameters": [
+                                            {
+                                                "name": "petId",
+                                                "type": "integer",
+                                                "paramType": "path"
+                                            },
+                                            {
+                                                "name": "vaccineFile",
+                                                "type": "File",
+                                                "paramType": "form"
                                             }
                                         ]
                                     }


### PR DESCRIPTION
When Resources/Operations are constructed from api-docs, all fields
(e.g. 'method') are unicode. In python 2.7 httplib attempts string
concatenation to construct POST bodies, which means that
UnicodeDecodeErrors occur if one includes binary data as a parameter.
Rather than change all api-doc fields to 'str', this branch casts only
fields used in httplib.

Might be prudent to file a followup issue to convert all test resource listings to unicode fields, since this is what the requests library returns.