### PR TITLE
[bravado] Make common HTTP Error for Fido and Requests clients. Refer: #100

### DIFF
--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -140,9 +140,8 @@ def add_response_detail_to_errors(e):
     :type e: :class: `requests.HTTPError`
     :raises HTTPError: :class: `bravado.exception.HTTPError`
     """
+    args = list(e.args)
     if hasattr(e, 'response') and hasattr(e.response, 'text'):
-        # e.args is a tuple, change to list for modifications
-        args = list(e.args)
         args[0] += (' : ' + e.response.text)
     raise HTTPError(*args), None, sys.exc_info()[2]
 

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -6,10 +6,12 @@
 
 import logging
 import urlparse
+import sys
 
 import requests
 import requests.auth
 
+from bravado.exception import HTTPError
 from bravado.mapping.http_client import HttpClient
 from bravado.mapping.http_future import HttpFuture
 from bravado.mapping.response import ResponseLike
@@ -139,7 +141,7 @@ def add_response_detail_to_errors(e):
         args = list(e.args)
         args[0] += (' : ' + e.response.text)
         e.args = tuple(args)
-    raise e
+    raise HTTPError(*e.args), None, sys.exc_info()[2]
 
 
 class RequestsResponseAdapter(ResponseLike):

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -135,13 +135,16 @@ def add_response_detail_to_errors(e):
     """Specific to requests errors. Error detail is not
     directly visible in `raise_for_status` trace, instead it is
     located under `e.response.text`
+
+    :param e: Exception object
+    :type e: :class: `requests.HTTPError`
+    :raises HTTPError: :class: `bravado.exception.HTTPError`
     """
     if hasattr(e, 'response') and hasattr(e.response, 'text'):
         # e.args is a tuple, change to list for modifications
         args = list(e.args)
         args[0] += (' : ' + e.response.text)
-        e.args = tuple(args)
-    raise HTTPError(*e.args), None, sys.exc_info()[2]
+    raise HTTPError(*args), None, sys.exc_info()[2]
 
 
 class RequestsResponseAdapter(ResponseLike):

--- a/tests/functional/response_func_test.py
+++ b/tests/functional/response_func_test.py
@@ -6,10 +6,10 @@ import functools
 
 from jsonschema.exceptions import ValidationError
 import pytest
-from requests import HTTPError
 
 from bravado.client import SwaggerClient
 from bravado.compat import json
+from bravado.exception import HTTPError
 from tests.functional.conftest import register_spec, register_get, API_DOCS_URL
 
 

--- a/tests/requests_client/add_response_detail_to_errors_test.py
+++ b/tests/requests_client/add_response_detail_to_errors_test.py
@@ -14,3 +14,11 @@ def test_response_message_gets_appended():
     with pytest.raises(HTTPError) as excinfo:
         add_response_detail_to_errors(e)
     assert 'asdf : bla' == str(excinfo.value)
+
+
+def test_no_response_message_gets_appended():
+    e = requests.HTTPError('asdf')
+
+    with pytest.raises(HTTPError) as excinfo:
+        add_response_detail_to_errors(e)
+    assert 'asdf' == str(excinfo.value)

--- a/tests/requests_client/add_response_details_to_errors_test.py
+++ b/tests/requests_client/add_response_details_to_errors_test.py
@@ -1,0 +1,16 @@
+from mock import Mock
+import requests
+
+import pytest
+
+from bravado.exception import HTTPError
+from bravado.requests_client import add_response_detail_to_errors
+
+
+def test_response_message_gets_appended():
+    e = requests.HTTPError('asdf')
+    e.response = Mock(text='bla')
+
+    with pytest.raises(HTTPError) as excinfo:
+        add_response_detail_to_errors(e)
+    assert 'asdf : bla' == str(excinfo.value)


### PR DESCRIPTION
Similar to #137. Fixes #100 and #108 for bravado release.