### PR TITLE
Set model attribute to None, instead of creating a default value.

### DIFF
--- a/swaggerpy/swagger_model.py
+++ b/swaggerpy/swagger_model.py
@@ -293,15 +293,11 @@ def set_props(model, **kwargs):
     types = getattr(model, '_swagger_types')
     arg_keys = kwargs.keys()
     for property_name, property_swagger_type in types.iteritems():
-        swagger_py_type = swagger_type.swagger_to_py_type(
-            property_swagger_type)
         # Assign all property values specified in kwargs
+        property_value = None
         if property_name in arg_keys:
             property_value = kwargs[property_name]
             arg_keys.remove(property_name)
-        else:
-            # If not in kwargs, provide a default value to the type
-            property_value = swagger_type.get_instance(swagger_py_type)
         setattr(model, property_name, property_value)
     if arg_keys:
         raise AttributeError(" %s are not defined for %s." % (arg_keys, model))

--- a/swaggerpy/swagger_type.py
+++ b/swaggerpy/swagger_type.py
@@ -47,28 +47,6 @@ ARRAY = 'array'
 
 COLON = ':'
 
-DATETIME_TYPES = set([datetime.datetime, datetime.date])
-
-
-def get_instance(py_type):
-    """Factory method to get default constructor invoked for the type
-
-    .. note::
-
-        get_instance() is meant to be called to get an instance of
-        primitive Python type. datetime() and date() are primitives in Swagger
-        but not Python, so return None for these.
-
-    Complex models are already set to None in swagger_to_py_type(), hence
-    this should be called only for values from SWAGGER_TO_PY_TYPE_MAPPING
-    """
-    if py_type is None:
-        return None
-    # datetime and date are not Python primitive types, return None for them.
-    if py_type in DATETIME_TYPES:
-        return None
-    return py_type()
-
 
 def primitive_formats():
     """returns Swagger primitive formats allowed after internal conversion.

--- a/tests/resource_model_test.py
+++ b/tests/resource_model_test.py
@@ -157,7 +157,7 @@ class ResourceTest(unittest.TestCase):
             u'http://localhost/api-docs').api_test
         User = resource.testHTTP._models['User']
         self.assertEqual(
-            {"schools": [], "id": 0L, "date": None, "datetime": None},
+            {"schools": None, "id": None, "date": None, "datetime": None},
             User().__dict__
         )
 
@@ -214,8 +214,8 @@ class ResourceTest(unittest.TestCase):
         resource = SwaggerClient.from_url(
             u'http://localhost/api-docs').api_test
         models = resource.testHTTP._models
-        user = models['User']()
-        school = models['School']()
+        school = models['School'](name='foo')
+        user = models['User'](id=1l, schools=[school])
         self.assertTrue(isinstance(user.id, long))
         self.assertTrue(isinstance(user.schools, list))
         self.assertTrue(isinstance(school.name, str))
@@ -421,7 +421,7 @@ class ResourceTest(unittest.TestCase):
         models = resource.testHTTP._models
         User = models['User']
         School = models['School']
-        user = User(schools=[School(name='a'), None])
+        user = User(id=1, schools=[School(name='a'), None])
         self.assertEqual(None, user.schools[1])
         self.assertEqual([{'name': 'a'}], user._flat_dict()['schools'])
 
@@ -468,11 +468,9 @@ class ResourceTest(unittest.TestCase):
             u'http://localhost/api-docs').api_test
         user = resource.testHTTP._models['User'](id=42)
         future = resource.testHTTPPost(body=user)
-        # Removed the 'school': None - key, value pair from dict
+        # Removed the 'schools': None - key, value pair from dict
         self.assertEqual(
-            json.dumps({'id': 42, 'schools': []}),
-            future._request.request.data,
-        )
+            json.dumps({'id': 42}), future._request.request.data)
 
     @httpretty.activate
     def test_error_on_finding_required_attributes_none(self):

--- a/tests/swagger_model_test.py
+++ b/tests/swagger_model_test.py
@@ -58,7 +58,7 @@ class TestCreateModelType(object):
     def test_create_model_type(self):
         model_type = swagger_model.create_model_type(self.model)
         expected = set(['id', 'category', 'name', 'status'])
-        instance = model_type(status='ok')
+        instance = model_type(status='ok', id=0, name='')
         assert set(vars(instance).keys()) == expected
         assert set(dir(instance)) == expected
         assert instance == model_type(id=0, name='', status='ok')


### PR DESCRIPTION
- Fixes #133 
- Note: Even for an array attribute, it will now set it to `None` instead of an earlier empty list.