### PR TITLE
Make API compatible with swagger-py

### DIFF
--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -1,18 +1,13 @@
 # -*- coding: utf-8 -*-
-
-#
-# Copyright (c) 2015, Yelp, Inc.
-#
-
 import logging
 
+from bravado_core.http_client import APP_FORM, HttpClient
+from bravado_core.param import stringify_body as param_stringify_body
+from bravado_core.response import ResponseLike
 import fido
 from yelp_uri import urllib_utf8
 
-from bravado_core.http_client import APP_FORM, HttpClient
-from bravado_core.http_future import HttpFuture
-from bravado_core.param import stringify_body as param_stringify_body
-from bravado_core.response import ResponseLike
+from bravado.http_future import HttpFuture
 from bravado.multipart_response import create_multipart_content
 
 log = logging.getLogger(__name__)

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -4,7 +4,6 @@ from bravado.exception import HTTPError
 DEFAULT_TIMEOUT_S = 5.0
 
 
-# TODO: move to bravado
 class HttpFuture(object):
     """A future which inputs HTTP params"""
 

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from bravado.exception import HTTPError
+
+DEFAULT_TIMEOUT_S = 5.0
+
+
+# TODO: move to bravado
+class HttpFuture(object):
+    """A future which inputs HTTP params"""
+
+    def __init__(self, future, response_adapter, callback):
+        """Kicks API call for Fido client
+
+        :param future: future object
+        :type future: :class: `concurrent.futures.Future`
+        :param response_adapter: Adapter which exposes json(), status_code()
+        :type response_adapter: :class: `bravado_core.response.ResponseLike`
+        :param callback: Function to be called on the response
+        """
+        self.future = future
+        self.response_adapter = response_adapter
+        self.response_callback = callback
+
+    def result(self, timeout=DEFAULT_TIMEOUT_S):
+        """Blocking call to wait for API response
+
+        :param timeout: Timeout in seconds for which client will get blocked
+        to receive the response
+        :return: swagger response return value when given a callback or the
+            http_response otherwise.
+        """
+        http_response = self.response_adapter(
+            self.future.result(timeout=timeout))
+
+        if self.response_callback:
+            swagger_return_value = self.response_callback(http_response)
+            return raise_http_error_based_on_status(
+                http_response, swagger_return_value)
+
+        return http_response
+
+
+def raise_http_error_based_on_status(http_response, swagger_return_value):
+    """
+    Mimic behavior of the swaggerpy 1.2 implementation for backwards
+    compatibility. Raise an HTTPError when the http status indicates a client
+    or server side error.
+
+    :param http_response: :class:`ResponseLike`
+    :param swagger_return_value: The return value of a swagger response if it
+        has one, None otherwise.
+    :return: swagger_return_value
+    :raises: HTTPError on 4XX and 5XX http errors
+    """
+    http_error_msg = None
+
+    if 400 <= http_response.status_code < 500:
+        http_error_msg = '{0} Client Error: {1}'.format(
+            http_response.status_code, swagger_return_value)
+
+    elif 500 <= http_response.status_code < 600:
+        http_error_msg = '{0} Server Error: {1}'.format(
+            http_response.status_code, swagger_return_value)
+
+    if http_error_msg:
+        raise HTTPError(http_error_msg, http_response, swagger_return_value)
+
+    return swagger_return_value

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -33,8 +33,9 @@ class HttpFuture(object):
 
         if self.response_callback:
             swagger_return_value = self.response_callback(http_response)
-            return raise_http_error_based_on_status(
+            raise_http_error_based_on_status(
                 http_response, swagger_return_value)
+            return swagger_return_value
 
         return http_response
 
@@ -48,7 +49,6 @@ def raise_http_error_based_on_status(http_response, swagger_return_value):
     :param http_response: :class:`ResponseLike`
     :param swagger_return_value: The return value of a swagger response if it
         has one, None otherwise.
-    :return: swagger_return_value
     :raises: HTTPError on 4XX and 5XX http errors
     """
     http_error_msg = None
@@ -63,5 +63,3 @@ def raise_http_error_based_on_status(http_response, swagger_return_value):
 
     if http_error_msg:
         raise HTTPError(http_error_msg, http_response, swagger_return_value)
-
-    return swagger_return_value

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -1,20 +1,16 @@
 # -*- coding: utf-8 -*-
-
-#
-# Copyright (c) 2015, Yelp, Inc.
-#
-
 import logging
-import urlparse
 import sys
+import urlparse
 
+from bravado_core.http_client import HttpClient
+from bravado_core.response import ResponseLike
 import requests
 import requests.auth
 
 from bravado.exception import HTTPError
-from bravado_core.http_client import HttpClient
-from bravado_core.http_future import HttpFuture
-from bravado_core.response import ResponseLike
+from bravado.http_future import HttpFuture
+
 
 log = logging.getLogger(__name__)
 

--- a/tests/functional/model_func_test.py
+++ b/tests/functional/model_func_test.py
@@ -93,7 +93,7 @@ def test_model_in_response(httprettified, swagger_dict, sample_model):
     register_spec(swagger_dict)
     register_get("http://localhost/test_http", body=json.dumps(sample_model))
     client = SwaggerClient.from_url(API_DOCS_URL)
-    status, result = client.api_test.testHTTP().result()
+    result = client.api_test.testHTTP().result()
     User = client.get_model('User')
     School = client.get_model('School')
     assert isinstance(result, User)
@@ -123,7 +123,7 @@ def test_additionalProperty_in_model_in_response(
     sample_model["extra"] = 42
     register_get("http://localhost/test_http", body=json.dumps(sample_model))
     resource = SwaggerClient.from_url(API_DOCS_URL).api_test
-    status, result = resource.testHTTP().result()
+    result = resource.testHTTP().result()
     assert result.extra == 42
 
 

--- a/tests/functional/request_func_test.py
+++ b/tests/functional/request_func_test.py
@@ -73,8 +73,7 @@ def test_parameter_in_path_of_request(httprettified, swagger_dict):
     register_spec(swagger_dict)
     register_get('http://localhost/test_http/42?test_param=foo')
     resource = SwaggerClient.from_url(API_DOCS_URL).api_test
-    resp = resource.testHTTP(test_param="foo", param_id="42").result()
-    assert (200, None) == resp
+    assert resource.testHTTP(test_param="foo", param_id="42").result() is None
 
 
 def test_default_value_in_request(httprettified, swagger_dict):
@@ -104,4 +103,4 @@ def test_array_with_collection_format_in_path_of_request(
     register_spec(swagger_dict)
     register_get('http://localhost/test_http/40,41,42')
     resource = SwaggerClient.from_url(API_DOCS_URL).api_test
-    assert (200, None) == resource.testHTTP(param_ids=[40, 41, 42]).result()
+    assert resource.testHTTP(param_ids=[40, 41, 42]).result() is None

--- a/tests/functional/response_func_test.py
+++ b/tests/functional/response_func_test.py
@@ -18,11 +18,9 @@ register_test_http = functools.partial(
     'http://localhost/test_http?test_param=foo')
 
 
-def assert_status_and_result(http_status, result):
+def assert_result(expected_result):
     resource = SwaggerClient.from_url(API_DOCS_URL).api_test
-    status, result = resource.testHTTP(test_param='foo').result()
-    assert status == http_status
-    assert result == result
+    assert expected_result == resource.testHTTP(test_param='foo').result()
 
 
 def assert_raises_and_matches(exc_type, match_str):
@@ -48,7 +46,7 @@ def test_primitive_types_returned_in_response(httprettified, swagger_dict):
     for rtype, rvalue in rtypes.iteritems():
         register_spec(swagger_dict, {'type': rtype})
         register_test_http(body=json.dumps(rvalue))
-        assert_status_and_result(200, rvalue)
+        assert_result(rvalue)
 
 
 def test_invalid_primitive_types_in_response_raises_ValidationError(
@@ -69,14 +67,14 @@ def test_unstructured_json_in_response(httprettified, swagger_dict):
     response_spec = {'type': 'object', 'additionalProperties': True}
     register_spec(swagger_dict, response_spec)
     register_test_http(body='{"some_foo": "bar"}')
-    assert_status_and_result(200, {'some_foo': 'bar'})
+    assert_result({'some_foo': 'bar'})
 
 
 def test_date_format_in_reponse(httprettified, swagger_dict):
     response_spec = {'type': 'string', 'format': 'date'}
     register_spec(swagger_dict, response_spec)
     register_test_http(body=json.dumps("2014-06-10"))
-    assert_status_and_result(200, datetime.date(2014, 6, 10))
+    assert_result(datetime.date(2014, 6, 10))
 
 
 def test_array_in_response(httprettified, swagger_dict):
@@ -89,4 +87,4 @@ def test_array_in_response(httprettified, swagger_dict):
     register_spec(swagger_dict, response_spec)
     expected_array = ['inky', 'dinky', 'doo']
     register_test_http(body=json.dumps(expected_array))
-    assert_status_and_result(200, expected_array)
+    assert_result(expected_array)

--- a/tests/functional/response_func_test.py
+++ b/tests/functional/response_func_test.py
@@ -10,6 +10,7 @@ import pytest
 from bravado.client import SwaggerClient
 from bravado.compat import json
 from bravado.exception import HTTPError
+from bravado.fido_client import FidoClient
 from tests.functional.conftest import register_spec, register_get, API_DOCS_URL
 
 

--- a/tests/functional/response_func_test.py
+++ b/tests/functional/response_func_test.py
@@ -10,7 +10,6 @@ import pytest
 from bravado.client import SwaggerClient
 from bravado.compat import json
 from bravado.exception import HTTPError
-from bravado.fido_client import FidoClient
 from tests.functional.conftest import register_spec, register_get, API_DOCS_URL
 
 

--- a/tests/functional/spec_func_test.py
+++ b/tests/functional/spec_func_test.py
@@ -23,7 +23,7 @@ def test_correct_route_with_basePath_as_slash(httprettified, swagger_dict):
     register_spec(swagger_dict)
     register_get("http://localhost/test_http?test_param=foo")
     resource = SwaggerClient.from_url(API_DOCS_URL).api_test
-    assert (200, None) == resource.testHTTP(test_param="foo").result()
+    assert resource.testHTTP(test_param="foo").result() is None
 
 
 def test_basePath_works(httprettified, swagger_dict):
@@ -63,4 +63,4 @@ def test_correct_route_with_basePath_no_slash(httprettified, swagger_dict):
     swagger_dict["basePath"] = "/lame/test"
     register_spec(swagger_dict)
     resource = SwaggerClient.from_url(API_DOCS_URL).api_test
-    assert (200, None) == resource.testHTTP(test_param="foo").result()
+    assert resource.testHTTP(test_param="foo").result() is None

--- a/tests/http_future/HttpFuture/result_test.py
+++ b/tests/http_future/HttpFuture/result_test.py
@@ -1,0 +1,49 @@
+from concurrent.futures import Future
+
+from bravado_core.response import ResponseLike
+from mock import Mock, patch
+import pytest
+
+from bravado.http_future import HTTPError, HttpFuture
+
+
+def test_no_response_callback():
+    # This use case is for http requests that are made outside of the
+    # swagger spec e.g. retrieving the swagger schema
+    response_adapter_instance = Mock(spec=ResponseLike)
+    response_adapter_type = Mock(return_value=response_adapter_instance)
+    http_future = HttpFuture(
+        future=Mock(spec=Future),
+        response_adapter=response_adapter_type,
+        callback=None)
+
+    assert response_adapter_instance == http_future.result()
+
+
+def test_200_success():
+    response_callback = Mock(return_value='hello world')
+    response_adapter_instance = Mock(spec=ResponseLike, status_code=200)
+    response_adapter_type = Mock(return_value=response_adapter_instance)
+
+    http_future = HttpFuture(
+        future=Mock(spec=Future),
+        response_adapter=response_adapter_type,
+        callback=response_callback)
+
+    assert 'hello world' == http_future.result()
+
+
+@patch('bravado.http_future.raise_http_error_based_on_status',
+       side_effect=HTTPError)
+def test_4XX_5XX_failure(_):
+    response_callback = Mock(return_value='hello world')
+    response_adapter_instance = Mock(spec=ResponseLike, status_code=400)
+    response_adapter_type = Mock(return_value=response_adapter_instance)
+
+    http_future = HttpFuture(
+        future=Mock(spec=Future),
+        response_adapter=response_adapter_type,
+        callback=response_callback)
+
+    with pytest.raises(HTTPError):
+        http_future.result()

--- a/tests/http_future/__init__.py
+++ b/tests/http_future/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'spatel'

--- a/tests/http_future/raise_http_error_based_on_status_test.py
+++ b/tests/http_future/raise_http_error_based_on_status_test.py
@@ -7,8 +7,8 @@ from bravado.http_future import raise_http_error_based_on_status, HTTPError
 
 def test_200():
     http_response = Mock(spec=ResponseLike, status_code=200)
-    value = raise_http_error_based_on_status(http_response, 'hello world')
-    assert 'hello world' == value
+    # no error raised == success
+    raise_http_error_based_on_status(http_response, 'hello world')
 
 
 def test_http_error_raised_on_4XX_client_error():

--- a/tests/http_future/raise_http_error_based_on_status_test.py
+++ b/tests/http_future/raise_http_error_based_on_status_test.py
@@ -1,0 +1,27 @@
+from bravado_core.response import ResponseLike
+from mock import Mock
+import pytest
+
+from bravado.http_future import raise_http_error_based_on_status, HTTPError
+
+
+def test_200():
+    http_response = Mock(spec=ResponseLike, status_code=200)
+    value = raise_http_error_based_on_status(http_response, 'hello world')
+    assert 'hello world' == value
+
+
+def test_http_error_raised_on_4XX_client_error():
+    http_response = Mock(spec=ResponseLike, status_code=404)
+    with pytest.raises(HTTPError) as excinfo:
+        raise_http_error_based_on_status(
+            http_response, {'error': 'Object not found'})
+    assert 'Client Error' in str(excinfo.value)
+
+
+def test_http_error_raised_on_5XX_server_error():
+    http_response = Mock(spec=ResponseLike, status_code=500)
+    with pytest.raises(HTTPError) as excinfo:
+        raise_http_error_based_on_status(
+            http_response, {'error': 'kaboom'})
+    assert 'Server Error' in str(excinfo.value)


### PR DESCRIPTION
- Moved `HttpFuture` from bravado-core to bravado
- HTTPError raised on client or server side errors based on HTTP status code to match swagger-py
- See sister PR in bravado-core - https://github.com/Yelp/bravado-core/pull/12